### PR TITLE
Parse verification unit binding indications

### DIFF
--- a/vhdl_parser/src/ast.rs
+++ b/vhdl_parser/src/ast.rs
@@ -928,12 +928,34 @@ pub struct ComponentSpecification {
     pub component_name: SelectedName,
 }
 
-/// LRM 7.3 Configuration specification
-// @TODO There is also compound
+
+/// LRM 7.3.4 Verification unit binding indication
 #[derive(PartialEq, Debug, Clone)]
-pub struct ConfigurationSpecification {
+pub struct VUnitBindingIndication {
+    pub vunit_list: Vec<WithPos<Name>>,
+}
+
+
+/// LRM 7.3 Compound Configuration specification
+#[derive(PartialEq, Debug, Clone)]
+pub struct CompoundConfigurationSpecification {
     pub spec: ComponentSpecification,
     pub bind_ind: BindingIndication,
+    pub vunit_bind_inds: Vec<VUnitBindingIndication>,
+}
+
+/// LRM 7.3 Simple Configuration specification
+#[derive(PartialEq, Debug, Clone)]
+pub struct SimpleConfigurationSpecification {
+    pub spec: ComponentSpecification,
+    pub bind_ind: BindingIndication,
+}
+
+/// LRM 7.3 Configuration specification
+#[derive(PartialEq, Debug, Clone)]
+pub enum ConfigurationSpecification {
+    Simple(SimpleConfigurationSpecification),
+    Compound(CompoundConfigurationSpecification),
 }
 
 /// LRM 3.4 Configuration declarations
@@ -972,6 +994,7 @@ pub struct ConfigurationDeclaration {
     pub ident: Ident,
     pub entity_name: SelectedName,
     pub decl: Vec<ConfigurationDeclarativeItem>,
+    pub vunit_bind_inds: Option<Vec<VUnitBindingIndication>>,
     pub block_config: Option<BlockConfiguration>,
 }
 

--- a/vhdl_parser/src/ast.rs
+++ b/vhdl_parser/src/ast.rs
@@ -970,6 +970,7 @@ pub enum ConfigurationDeclarativeItem {
 pub struct ComponentConfiguration {
     pub spec: ComponentSpecification,
     pub bind_ind: Option<BindingIndication>,
+    pub vunit_bind_inds: Option<Vec<VUnitBindingIndication>>,
     pub block_config: Option<BlockConfiguration>,
 }
 

--- a/vhdl_parser/src/configuration.rs
+++ b/vhdl_parser/src/configuration.rs
@@ -6,11 +6,12 @@
 
 use ast::{
     BindingIndication, BlockConfiguration, ComponentConfiguration, ComponentSpecification,
-    ConfigurationDeclaration, ConfigurationDeclarativeItem, ConfigurationItem,
-    ConfigurationSpecification, EntityAspect, InstantiationList, Name,
+    CompoundConfigurationSpecification, ConfigurationDeclaration, ConfigurationDeclarativeItem,
+    ConfigurationItem, ConfigurationSpecification, EntityAspect, InstantiationList, Name,
+    SimpleConfigurationSpecification, VUnitBindingIndication,
 };
 use common::error_on_end_identifier_mismatch;
-use context::parse_use_clause;
+use context::parse_use_clause_no_keyword;
 use message::{Message, MessageHandler, ParseResult};
 use names::{parse_name, parse_name_initial_token, parse_selected_name, to_simple_name};
 use source::WithPos;
@@ -210,6 +211,40 @@ fn parse_block_configuration_known_keyword(
     parse_block_configuration_known_name(stream, name, messages)
 }
 
+fn parse_vunit_binding_indication_list_known_keyword(
+    stream: &mut TokenStream,
+) -> ParseResult<Vec<VUnitBindingIndication>> {
+    let mut indications = Vec::new();
+    loop {
+        stream.expect_kind(Vunit)?;
+
+        let mut vunit_list = Vec::new();
+
+        let vunit_bind_ind = loop {
+            vunit_list.push(parse_name(stream)?);
+            let token = stream.peek_expect()?;
+            try_token_kind!(
+                token,
+                Comma => {
+                    stream.move_after(&token);
+                },
+                SemiColon => {
+                    stream.move_after(&token);
+                    break VUnitBindingIndication { vunit_list };
+                }
+            );
+        };
+
+        indications.push(vunit_bind_ind);
+
+        if !stream.skip_if_kind(Use)? {
+            break;
+        }
+    }
+    Ok(indications)
+}
+
+/// LRM 3.4 Configuration declaration
 pub fn parse_configuration_declaration(
     stream: &mut TokenStream,
     messages: &mut MessageHandler,
@@ -221,26 +256,30 @@ pub fn parse_configuration_declaration(
     stream.expect_kind(Is)?;
     let mut decl = Vec::new();
 
-    let block_config = loop {
+    let vunit_bind_inds = loop {
         let token = stream.peek_expect()?;
-        try_token_kind!(
-            token,
-            End => {
-                stream.move_after(&token);
-                break None;
-            },
+        match token.kind {
             Use => {
-                decl.push(ConfigurationDeclarativeItem::Use(parse_use_clause(stream)?));
-            },
-            For => {
                 stream.move_after(&token);
-                let block_config = parse_block_configuration_known_keyword(stream, messages)?;
-                stream.expect_kind(End)?;
-                break Some(block_config);
-            }
-        );
+                if stream.peek_kind()? == Some(Vunit) {
+                    break Some(parse_vunit_binding_indication_list_known_keyword(stream)?);
+                }
+
+                decl.push(ConfigurationDeclarativeItem::Use(parse_use_clause_no_keyword(token, stream)?));
+            },
+            _ => break None,
+        }
     };
 
+    let block_config = if stream.skip_if_kind(For)? {
+        let block_config = parse_block_configuration_known_keyword(stream, messages)?;
+        Some(block_config)
+    } else {
+        None
+    };
+
+
+    stream.expect_kind(End)?;
     stream.pop_if_kind(Configuration)?;
     let end_ident = stream.pop_optional_ident()?;
     if let Some(msg) = error_on_end_identifier_mismatch(&ident, &end_ident) {
@@ -251,11 +290,13 @@ pub fn parse_configuration_declaration(
         ident,
         entity_name,
         decl,
+        vunit_bind_inds,
         block_config,
     })
 }
 
-/// LRM 7.3 Configuration specification
+
+/// LRM 7.3 Configuration Specification
 pub fn parse_configuration_specification(
     stream: &mut TokenStream,
 ) -> ParseResult<ConfigurationSpecification> {
@@ -263,7 +304,20 @@ pub fn parse_configuration_specification(
     match parse_component_specification_or_name(stream)? {
         ComponentSpecificationOrName::ComponentSpec(spec) => {
             let bind_ind = parse_binding_indication_known_keyword(stream)?;
-            Ok(ConfigurationSpecification { spec, bind_ind })
+            if stream.skip_if_kind(Use)? {
+                let vunit_bind_inds = parse_vunit_binding_indication_list_known_keyword(stream)?;
+                stream.expect_kind(End)?;
+                stream.expect_kind(For)?;
+                stream.expect_kind(SemiColon)?;
+                Ok(ConfigurationSpecification::Compound(CompoundConfigurationSpecification { spec, bind_ind, vunit_bind_inds }))
+
+            } else {
+                if stream.skip_if_kind(End)? {
+                    stream.expect_kind(For)?;
+                    stream.expect_kind(SemiColon)?;
+                }
+                Ok(ConfigurationSpecification::Simple(SimpleConfigurationSpecification { spec, bind_ind }))
+            }
         }
         ComponentSpecificationOrName::Name(name) => {
             return Err(Message::error(name, "Expected component specification"));
@@ -290,6 +344,7 @@ end;
                 ident: code.s1("cfg").ident(),
                 entity_name: code.s1("entity_name").selected_name(),
                 decl: vec![],
+                vunit_bind_inds: None,
                 block_config: None
             }
         );
@@ -309,6 +364,7 @@ end configuration cfg;
                 ident: code.s1("cfg").ident(),
                 entity_name: code.s1("entity_name").selected_name(),
                 decl: vec![],
+                vunit_bind_inds: None,
                 block_config: None
             }
         );
@@ -332,6 +388,33 @@ end configuration cfg;
                     ConfigurationDeclarativeItem::Use(code.s1("use lib.foo.bar;").use_clause()),
                     ConfigurationDeclarativeItem::Use(code.s1("use lib2.foo.bar;").use_clause())
                 ],
+                vunit_bind_inds: None,
+                block_config: None
+            }
+        );
+    }
+
+    #[test]
+    fn configuration_vunit_binding_indication() {
+        let code = Code::new(
+            "\
+configuration cfg of entity_name is
+  use lib.foo.bar;
+  use vunit baz.foobar;
+end configuration cfg;
+",
+        );
+        assert_eq!(
+            code.with_stream_no_messages(parse_configuration_declaration),
+            ConfigurationDeclaration {
+                ident: code.s1("cfg").ident(),
+                entity_name: code.s1("entity_name").selected_name(),
+                decl: vec![
+                    ConfigurationDeclarativeItem::Use(code.s1("use lib.foo.bar;").use_clause()),
+                ],
+                vunit_bind_inds: Some(vec![
+                    VUnitBindingIndication { vunit_list: vec![ code.s1("baz.foobar").name() ] }
+                ]),
                 block_config: None
             }
         );
@@ -353,6 +436,7 @@ end configuration cfg;
                 ident: code.s1("cfg").ident(),
                 entity_name: code.s1("entity_name").selected_name(),
                 decl: vec![],
+                vunit_bind_inds: None,
                 block_config: Some(BlockConfiguration {
                     block_spec: code.s1("rtl(0)").name(),
                     use_clauses: vec![],
@@ -382,6 +466,7 @@ end configuration cfg;
                 ident: code.s1("cfg").ident(),
                 entity_name: code.s1("entity_name").selected_name(),
                 decl: vec![],
+                vunit_bind_inds: None,
                 block_config: Some(BlockConfiguration {
                     block_spec: code.s1("rtl(0)").name(),
                     use_clauses: vec![],
@@ -422,6 +507,7 @@ end configuration cfg;
                 ident: code.s1("cfg").ident(),
                 entity_name: code.s1("entity_name").selected_name(),
                 decl: vec![],
+                vunit_bind_inds: None,
                 block_config: Some(BlockConfiguration {
                     block_spec: code.s1("rtl(0)").name(),
                     use_clauses: vec![],
@@ -463,6 +549,7 @@ end configuration cfg;
                 ident: code.s1("cfg").ident(),
                 entity_name: code.s1("entity_name").selected_name(),
                 decl: vec![],
+                vunit_bind_inds: None,
                 block_config: Some(BlockConfiguration {
                     block_spec: code.s1("rtl(0)").name(),
                     use_clauses: vec![],
@@ -512,6 +599,7 @@ end configuration cfg;
                 ident: code.s1("cfg").ident(),
                 entity_name: code.s1("entity_name").selected_name(),
                 decl: vec![],
+                vunit_bind_inds: None,
                 block_config: Some(BlockConfiguration {
                     block_spec: code.s1("rtl(0)").name(),
                     use_clauses: vec![],
@@ -597,26 +685,80 @@ end configuration cfg;
     }
 
     #[test]
-    fn configuration_specification() {
+    fn simple_configuration_specification() {
         let code = Code::new("for all : lib.pkg.comp use entity work.foo(rtl);");
 
         assert_eq!(
             code.with_stream(parse_configuration_specification),
-            ConfigurationSpecification {
-                spec: ComponentSpecification {
-                    instantiation_list: InstantiationList::All,
-                    component_name: code.s1("lib.pkg.comp").selected_name(),
-                },
-                bind_ind: BindingIndication {
-                    entity_aspect: Some(EntityAspect::Entity(
-                        code.s1("work.foo").selected_name(),
-                        Some(code.s1("rtl").ident())
-                    )),
-                    generic_map: None,
-                    port_map: None
+            ConfigurationSpecification::Simple (
+                SimpleConfigurationSpecification {
+                    spec: ComponentSpecification {
+                        instantiation_list: InstantiationList::All,
+                        component_name: code.s1("lib.pkg.comp").selected_name(),
+                    },
+                    bind_ind: BindingIndication {
+                        entity_aspect: Some(EntityAspect::Entity(
+                            code.s1("work.foo").selected_name(),
+                            Some(code.s1("rtl").ident())
+                        )),
+                        generic_map: None,
+                        port_map: None
+                    }
                 }
-            }
+            )
         );
     }
 
+    #[test]
+    fn simple_configuration_specification_end_for() {
+        let code = Code::new("for all : lib.pkg.comp use entity work.foo(rtl); end for;");
+
+        assert_eq!(
+            code.with_stream(parse_configuration_specification),
+            ConfigurationSpecification::Simple (
+                SimpleConfigurationSpecification {
+                    spec: ComponentSpecification {
+                        instantiation_list: InstantiationList::All,
+                        component_name: code.s1("lib.pkg.comp").selected_name(),
+                    },
+                    bind_ind: BindingIndication {
+                        entity_aspect: Some(EntityAspect::Entity(
+                            code.s1("work.foo").selected_name(),
+                            Some(code.s1("rtl").ident())
+                        )),
+                        generic_map: None,
+                        port_map: None
+                    }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn compound_configuration_specification() {
+        let code = Code::new("for all : lib.pkg.comp use entity work.foo(rtl); use vunit bar, baz; end for;");
+
+        assert_eq!(
+            code.with_stream(parse_configuration_specification),
+            ConfigurationSpecification::Compound (
+                CompoundConfigurationSpecification {
+                    spec: ComponentSpecification {
+                        instantiation_list: InstantiationList::All,
+                        component_name: code.s1("lib.pkg.comp").selected_name(),
+                    },
+                    bind_ind: BindingIndication {
+                        entity_aspect: Some(EntityAspect::Entity(
+                            code.s1("work.foo").selected_name(),
+                            Some(code.s1("rtl").ident())
+                        )),
+                        generic_map: None,
+                        port_map: None
+                    },
+                    vunit_bind_inds: vec![
+                        VUnitBindingIndication { vunit_list: vec![ code.s1("bar").name(), code.s1("baz").name() ] }
+                    ],
+                }
+            )
+        );
+    }
 }

--- a/vhdl_parser/src/context.rs
+++ b/vhdl_parser/src/context.rs
@@ -37,7 +37,7 @@ fn parse_library_clause_no_keyword(
 }
 
 /// LRM 12.4. Use clauses
-fn parse_use_clause_no_keyword(
+pub fn parse_use_clause_no_keyword(
     use_token: Token,
     stream: &mut TokenStream,
 ) -> ParseResult<WithPos<UseClause>> {

--- a/vhdl_parser/src/tokenizer.rs
+++ b/vhdl_parser/src/tokenizer.rs
@@ -94,6 +94,7 @@ pub enum Kind {
     Impure,
     Function,
     Procedure,
+    Vunit,
 
     // Unary operators
     Abs,
@@ -293,6 +294,7 @@ pub fn kind_str(kind: &Kind) -> &'static str {
         Impure => &"impure",
         Function => &"function",
         Procedure => &"procedure",
+        Vunit => &"vunit",
 
         // Unary operators
         Abs => &"abs",
@@ -1022,6 +1024,7 @@ impl Tokenizer {
             ("ror", ROR),
             ("mod", Mod),
             ("rem", Rem),
+            ("vunit", Vunit),
         ];
 
         let keywords: FnvHashMap<&[u8], Kind> = keywords


### PR DESCRIPTION
This change:
 * adds the ability to parse verification unit binding indications for configuration declarations (LRM 3.4), component configurations (LRM 3.4.3), and compound configuration specifications (LRM 7.3).
 * adds the 'vunit' keyword as a token kind.
 * makes the 'parse_use_clause_no_keyword' function public inside the crate. I did this to be able to parse the use_clause in parse_configuration_declation less awkwarldy.