### PR TITLE
Update Dockerfile to allow easy usage of language server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,3 @@ FROM scratch
 ARG CRATE
 COPY --from=builder /volume/target/x86_64-unknown-linux-musl/release/$CRATE ./app
 ENTRYPOINT ["./app"]
-CMD ["--help"]


### PR DESCRIPTION
This removes the default `--help` command from the Dockerfile to allow easy usage of the language server.
It allows people with docker installed to use the published image to run the language server. 