### PR TITLE
Add shutdown method and exit notification to language server

### DIFF
--- a/vhdl_ls/src/stdio_server.rs
+++ b/vhdl_ls/src/stdio_server.rs
@@ -80,7 +80,10 @@ pub fn start() {
             let request = read_request(&mut stdin.lock());
             match request_sender.send(request) {
                 Ok(_) => continue,
-                Err(_) => break,
+                Err(_) => {
+                    eprintln!("Channel hung up. Unlocking stdin handle.");
+                    break;
+                }
             }
         }
     });
@@ -94,6 +97,7 @@ pub fn start() {
                     send_response(&mut stdout, &response);
                 }
                 Err(_) => {
+                    eprintln!("Channel hung up.");
                     break;
                 }
             }
@@ -109,6 +113,7 @@ pub fn start() {
                 }
             }
             Err(_) => {
+                eprintln!("Channel hung up.");
                 break;
             }
         }

--- a/vhdl_ls/src/stdio_server.rs
+++ b/vhdl_ls/src/stdio_server.rs
@@ -36,11 +36,25 @@ pub fn start() {
     });
 
     let server = lang_server.clone();
+    io.add_method("shutdown", move |params: Params| {
+        let result = server.lock().unwrap().shutdown_server(params.parse()?)?;
+        Ok(serde_json::to_value(result).map_err(|_| jsonrpc_core::Error::internal_error())?)
+    });
+
+    let server = lang_server.clone();
     io.add_notification("initialized", move |params: Params| {
         server
             .lock()
             .unwrap()
             .initialized_notification(params.parse().unwrap())
+    });
+
+    let server = lang_server.clone();
+    io.add_notification("exit", move |params: Params| {
+        server
+            .lock()
+            .unwrap()
+            .exit_notification(params.parse().unwrap())
     });
 
     let server = lang_server.clone();
@@ -64,24 +78,39 @@ pub fn start() {
         let stdin = io::stdin();
         loop {
             let request = read_request(&mut stdin.lock());
-            request_sender.send(request).unwrap();
+            match request_sender.send(request) {
+                Ok(_) => continue,
+                Err(_) => break,
+            }
         }
     });
 
-    // Spawn thread to write notificaitons to stdout
+    // Spawn thread to write notifications to stdout
     spawn(move || {
         let mut stdout = io::stdout();
         loop {
-            let response: String = response_receiver.recv().unwrap();
-            send_response(&mut stdout, &response);
+            match response_receiver.recv() {
+                Ok(response) => {
+                    send_response(&mut stdout, &response);
+                }
+                Err(_) => {
+                    break;
+                }
+            }
         }
     });
 
     loop {
-        let request = request_receiver.recv().unwrap();
-        let response = io.handle_request_sync(&request);
-        if let Some(response) = response {
-            response_sender.send(response).unwrap();
+        match request_receiver.recv() {
+            Ok(request) => {
+                let response = io.handle_request_sync(&request);
+                if let Some(response) = response {
+                    response_sender.send(response).unwrap();
+                }
+            }
+            Err(_) => {
+                break;
+            }
         }
     }
 }

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -50,8 +50,20 @@ impl<T: RpcChannel + Clone> VHDLServer<T> {
         Ok(result)
     }
 
+    pub fn shutdown_server(&mut self, _params: ()) -> jsonrpc_core::Result<()> {
+        self.server = None;
+        Ok(())
+    }
+
     fn mut_server(&mut self) -> &mut InitializedVHDLServer<T> {
         self.server.as_mut().expect("Expected initialized server")
+    }
+
+    pub fn exit_notification(&mut self, _params: ()) {
+        match self.server {
+            Some(_) => ::std::process::exit(1),
+            None => ::std::process::exit(0),
+        }
     }
 
     pub fn initialized_notification(&mut self, params: InitializedParams) {
@@ -96,7 +108,8 @@ impl<T: RpcChannel + Clone> InitializedVHDLServer<T> {
                         ),
                     )
                 })
-            }).and_then(|root_path| {
+            })
+            .and_then(|root_path| {
                 let config_file = root_path.join("vhdl_ls.toml");
                 Config::read_file_path(&config_file)
             });
@@ -492,7 +505,8 @@ mod tests {
                         "No expected value, got method={} {:?}",
                         method, notification
                     )
-                }).unwrap();
+                })
+                .unwrap();
 
             match expected {
                 RpcExpected::Notification {
@@ -580,7 +594,8 @@ mod tests {
         let code = "
 entity ent is
 end entity ent;
-".to_owned();
+"
+        .to_owned();
 
         let did_open = DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
@@ -614,7 +629,8 @@ end entity ent;
         let code = "
 entity ent is
 end entity ent2;
-".to_owned();
+"
+        .to_owned();
 
         let did_open = DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
@@ -652,7 +668,8 @@ end entity ent2;
         let code = "
 entity ent is
 end entity ent;
-".to_owned();
+"
+        .to_owned();
 
         let did_change = DidChangeTextDocumentParams {
             text_document: VersionedTextDocumentIdentifier {

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -108,8 +108,7 @@ impl<T: RpcChannel + Clone> InitializedVHDLServer<T> {
                         ),
                     )
                 })
-            })
-            .and_then(|root_path| {
+            }).and_then(|root_path| {
                 let config_file = root_path.join("vhdl_ls.toml");
                 Config::read_file_path(&config_file)
             });
@@ -505,8 +504,7 @@ mod tests {
                         "No expected value, got method={} {:?}",
                         method, notification
                     )
-                })
-                .unwrap();
+                }).unwrap();
 
             match expected {
                 RpcExpected::Notification {
@@ -594,8 +592,7 @@ mod tests {
         let code = "
 entity ent is
 end entity ent;
-"
-        .to_owned();
+".to_owned();
 
         let did_open = DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
@@ -629,8 +626,7 @@ end entity ent;
         let code = "
 entity ent is
 end entity ent2;
-"
-        .to_owned();
+".to_owned();
 
         let did_open = DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
@@ -668,8 +664,7 @@ end entity ent2;
         let code = "
 entity ent is
 end entity ent;
-"
-        .to_owned();
+".to_owned();
 
         let did_change = DidChangeTextDocumentParams {
             text_document: VersionedTextDocumentIdentifier {


### PR DESCRIPTION
This adds the shutdown method and exit notification to the language server to prevent errors when using this with a client which use this method and notification to stop the server.
Can you please review? I'm not sure if this correctly stops the spawned threads and closes the channels.