### PR TITLE
Add env_logger to vhdl_ls

### DIFF
--- a/vhdl_ls/Cargo.toml
+++ b/vhdl_ls/Cargo.toml
@@ -20,6 +20,8 @@ serde = "^1"
 languageserver-types = "^0"
 url = "^1"
 fnv = "^1"
+log = "0.4.6"
+env_logger = "0.6.0"
 
 [dev-dependencies]
 tempfile = "^3"

--- a/vhdl_ls/src/lib.rs
+++ b/vhdl_ls/src/lib.rs
@@ -4,6 +4,9 @@
 //
 // Copyright (c) 2018, Olof Kraigher olof.kraigher@gmail.com
 
+#[macro_use]
+extern crate log;
+
 mod stdio_server;
 mod vhdl_server;
 pub use stdio_server::start;

--- a/vhdl_ls/src/main.rs
+++ b/vhdl_ls/src/main.rs
@@ -6,6 +6,12 @@
 
 extern crate vhdl_ls;
 
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
 fn main() {
+    env_logger::init();
+    info!("Starting language server");
     vhdl_ls::start();
 }

--- a/vhdl_ls/src/stdio_server.rs
+++ b/vhdl_ls/src/stdio_server.rs
@@ -81,7 +81,7 @@ pub fn start() {
             match request_sender.send(request) {
                 Ok(_) => continue,
                 Err(_) => {
-                    eprintln!("Channel hung up. Unlocking stdin handle.");
+                    info!("Channel hung up. Unlocking stdin handle.");
                     break;
                 }
             }
@@ -97,7 +97,7 @@ pub fn start() {
                     send_response(&mut stdout, &response);
                 }
                 Err(_) => {
-                    eprintln!("Channel hung up.");
+                    info!("Channel hung up.");
                     break;
                 }
             }
@@ -113,7 +113,7 @@ pub fn start() {
                 }
             }
             Err(_) => {
-                eprintln!("Channel hung up.");
+                info!("Channel hung up.");
                 break;
             }
         }
@@ -128,12 +128,12 @@ fn read_request(reader: &mut BufRead) -> String {
         .take(content_length)
         .read_to_string(&mut request)
         .unwrap();
-    eprintln!("DEBUG GOT REQUEST: {:?}", request);
+    trace!("GOT REQUEST: {:?}", request);
     request
 }
 
 fn send_response(writer: &mut Write, response: &str) {
-    eprintln!("DEBUG SEND RESPONSE: {:?}", response);
+    trace!("SEND RESPONSE: {:?}", response);
     write!(writer, "Content-Length: {}\r\n", response.len());
     write!(writer, "\r\n");
     write!(writer, "{}", response);
@@ -167,7 +167,7 @@ fn read_header(reader: &mut BufRead) -> u64 {
     reader.read_line(&mut buffer).unwrap();
     let fields = buffer.trim_end().clone().split(": ").collect::<Vec<&str>>();
     if fields.get(0) != Some(&"Content-Length") {
-        eprintln!("{:?}", fields);
+        trace!("{:?}", fields);
         panic!();
     }
     let content_length = fields.get(1).unwrap().parse::<u64>().unwrap();
@@ -180,16 +180,16 @@ fn read_header(reader: &mut BufRead) -> u64 {
 
     let fields = buffer.trim_end().clone().split(": ").collect::<Vec<&str>>();
     if fields.get(0) != Some(&"Content-Type") {
-        eprintln!("{:?}", fields);
+        trace!("{:?}", fields);
         panic!();
     } else {
-        eprintln!("got Content-Type: {}", fields.get(1).unwrap());
+        trace!("got Content-Type: {}", fields.get(1).unwrap());
     }
 
     let mut buffer = String::new();
     reader.read_line(&mut buffer).unwrap();
     if buffer != "\r\n" {
-        eprintln!("{:?}", buffer);
+        trace!("{:?}", buffer);
         panic!();
     }
 


### PR DESCRIPTION
This adds `log` and `env_logger` to the `vhdl_ls` crate. This allows users to disable output when preferred (e.g. Atom logs `stderr` message in the console, currently resulting in all the debug messages ending up there).