### PR TITLE
Allow rustfmt to fail for nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - rustup component add rustfmt-preview
 
 script:
-  - cargo fmt --package $CRATE -- --check
+  - cargo fmt --package $CRATE -- --check || [ "$TRAVIS_RUST_VERSION" = "nightly" ]
   - cargo clippy --package $CRATE || true
   - cargo build --package $CRATE
   - cargo test --package $CRATE


### PR DESCRIPTION
`rustfmt` was causing the nightly builds to fail. This change allows this task to fail for nightly builds. We should do the same for `clippy` once we get rid of the remaining warnings.