### PR TITLE
WIP: Parse comments

### DIFF
--- a/vhdl_parser/src/analysis/semantic.rs
+++ b/vhdl_parser/src/analysis/semantic.rs
@@ -287,7 +287,7 @@ impl<'r, 'a: 'r> Analyzer<'a> {
                             return Err(Message::error(
                                 prefix.as_ref(),
                                 "'.all' may not be the prefix of a selected name",
-                            ))
+                            ));
                         }
                         others => return Ok(others),
                     }

--- a/vhdl_parser/src/analysis/semantic.rs
+++ b/vhdl_parser/src/analysis/semantic.rs
@@ -640,6 +640,7 @@ impl<'r, 'a: 'r> Analyzer<'a> {
             Declaration::Type(TypeDeclaration {
                 ref ident,
                 def: TypeDefinition::Enumeration(ref enumeration),
+                comment: _,
             }) => {
                 region.add(
                     VisibleDeclaration::new(ident, AnyDeclaration::Declaration(decl)),

--- a/vhdl_parser/src/ast/mod.rs
+++ b/vhdl_parser/src/ast/mod.rs
@@ -467,6 +467,7 @@ pub enum TypeDefinition {
 pub struct TypeDeclaration {
     pub ident: Ident,
     pub def: TypeDefinition,
+    pub comment: Option<Latin1String>,
 }
 
 /// LRM 6.4.2 Object Declarations

--- a/vhdl_parser/src/latin_1.rs
+++ b/vhdl_parser/src/latin_1.rs
@@ -45,7 +45,8 @@ impl Latin1String {
     }
 
     pub fn push_newline(&mut self) {
-        self.bytes.extend(Latin1String::from_utf8("\n").unwrap().bytes);
+        self.bytes
+            .extend(Latin1String::from_utf8("\n").unwrap().bytes);
     }
 
     pub fn from_vec(bytes: Vec<u8>) -> Latin1String {

--- a/vhdl_parser/src/latin_1.rs
+++ b/vhdl_parser/src/latin_1.rs
@@ -40,6 +40,14 @@ impl Latin1String {
         }
     }
 
+    pub fn push(&mut self, pushed: &Latin1String) {
+        self.bytes.extend(pushed.bytes.iter());
+    }
+
+    pub fn push_newline(&mut self) {
+        self.bytes.extend(Latin1String::from_utf8("\n").unwrap().bytes);
+    }
+
     pub fn from_vec(bytes: Vec<u8>) -> Latin1String {
         Latin1String { bytes }
     }

--- a/vhdl_parser/src/source.rs
+++ b/vhdl_parser/src/source.rs
@@ -164,13 +164,7 @@ impl Source {
     }
 }
 
-#[derive(PartialEq, Clone, Debug)]
-pub struct Pos {
-    pub start: usize,
-    pub length: usize,
-}
-
-/// Lexical position in a file.
+/// Lexical position in a file
 #[derive(PartialEq, Clone, Debug, Eq, Hash)]
 pub struct SrcPos {
     /// The source

--- a/vhdl_parser/src/tokenizer.rs
+++ b/vhdl_parser/src/tokenizer.rs
@@ -166,7 +166,7 @@ pub enum Kind {
     RightArrow,
 
     LeadingComment,
-    TrailingComment
+    TrailingComment,
 }
 use self::Kind::*;
 
@@ -410,9 +410,6 @@ pub struct Token {
     pub pos: SrcPos,
 }
 
-///
-
-
 use std::convert::AsRef;
 impl AsRef<SrcPos> for Token {
     fn as_ref(&self) -> &SrcPos {
@@ -516,7 +513,6 @@ impl Token {
             Err(self.kinds_error(&[StringLiteral]))
         }
     }
-
 }
 
 /// Resolves ir1045
@@ -730,9 +726,7 @@ fn parse_string(
     parse_quoted(buffer, cursor, b'"', false)
 }
 
-fn parse_comment(
-    cursor: &mut ByteCursor,
-) -> Result<Latin1String, String> {
+fn parse_comment(cursor: &mut ByteCursor) -> Result<Latin1String, String> {
     let mut buffer = Latin1String::empty();
     while let Some(chr) = cursor.pop() {
         if (chr == b'\n') | (chr == b'\r') {
@@ -979,7 +973,6 @@ fn newline_before_token(cursor: &mut ByteCursor) -> bool {
     }
     newline
 }
-
 
 #[derive(Clone)]
 pub struct Tokenizer {
@@ -1253,10 +1246,10 @@ impl Tokenizer {
                                     } else {
                                         (TrailingComment, Value::String(comment))
                                     }
-                                },
+                                }
                                 Err(msg) => {
                                     error!(msg);
-                                },
+                                }
                             }
                         } else {
                             (Minus, Value::NoValue)
@@ -1361,19 +1354,12 @@ impl Tokenizer {
             }
         }
     }
-
 }
 
 /// Tokenize the code into a vector of tokens
 /// String symbols are added to the SymbolTable
 #[cfg(test)]
-fn tokenize_result(
-    code: &str,
-) -> (
-    Source,
-    Arc<SymbolTable>,
-    Vec<Result<Token, Message>>,
-) {
+fn tokenize_result(code: &str) -> (Source, Arc<SymbolTable>, Vec<Result<Token, Message>>) {
     let symtab = Arc::new(SymbolTable::new());
     let source = Source::from_str(code);
     let mut tokens = Vec::new();
@@ -2098,11 +2084,14 @@ end entity"
     #[test]
     fn extract_final_comments() {
         let (source, _, tokens) = tokenize_result("--final");
-        assert_eq!(tokens, vec![Ok(Token {
-            kind: LeadingComment,
-            value: Value::String(Latin1String::from_utf8_unchecked("final")),
-            pos: source.first_substr_pos("--final"),
-            })]);
+        assert_eq!(
+            tokens,
+            vec![Ok(Token {
+                kind: LeadingComment,
+                value: Value::String(Latin1String::from_utf8_unchecked("final")),
+                pos: source.first_substr_pos("--final"),
+            })]
+        );
     }
 
     #[test]
@@ -2124,53 +2113,55 @@ end entity"
         let temp_pos = source.first_substr_pos("- --");
         let minus_pos = source.pos(temp_pos.start, 1);
 
-        let expected_tokens: Vec<ParseResult<Token>>  = vec![
-                Ok(Token {
-                    kind: LeadingComment,
-                    value: Value::String(Latin1String::from_utf8_unchecked("this is a plus")),
-                    pos: source.first_substr_pos("--this is a plus"),
-                    }),
-                Ok(Token {
-                    kind: Plus,
-                    value: Value::NoValue,
-                    pos: source.first_substr_pos("+"),
-                }),
-                Ok(Token {
-                    kind: TrailingComment,
-                    value: Value::String(Latin1String::from_utf8_unchecked("this is still a plus")),
-                    pos: source.first_substr_pos("--this is still a plus"),
-                    }),
-                Ok(Token {
-                    kind: LeadingComment,
-                    value: Value::String(Latin1String::from_utf8_unchecked("- this is not a minus")),
-                    pos: source.first_substr_pos("--- this is not a minus"),
-                    }),
-                Ok(Token {
-                    kind: LeadingComment,
-                    value: Value::String(Latin1String::from_utf8_unchecked(" Neither is this")),
-                    pos: source.first_substr_pos("-- Neither is this"),
-                    }),
-                Ok(Token {
-                    kind: Minus,
-                    value: Value::NoValue,
-                    pos: minus_pos,
-                    }),
-                Ok(Token {
-                    kind: TrailingComment,
-                    value: Value::String(Latin1String::from_utf8_unchecked(" this is a minus")),
-                    pos: source.first_substr_pos("-- this is a minus"),
-                    }),
-                Ok(Token {
-                    kind: LeadingComment,
-                    value: Value::String(Latin1String::from_utf8_unchecked(" a comment at the end of the file")),
-                    pos: source.first_substr_pos("-- a comment at the end of the file"),
-                    }),
-                Ok(Token {
-                    kind: LeadingComment,
-                    value: Value::String(Latin1String::from_utf8_unchecked(" and another one")),
-                    pos: source.first_substr_pos("-- and another one"),
-                    }),
-            ];
+        let expected_tokens: Vec<ParseResult<Token>> = vec![
+            Ok(Token {
+                kind: LeadingComment,
+                value: Value::String(Latin1String::from_utf8_unchecked("this is a plus")),
+                pos: source.first_substr_pos("--this is a plus"),
+            }),
+            Ok(Token {
+                kind: Plus,
+                value: Value::NoValue,
+                pos: source.first_substr_pos("+"),
+            }),
+            Ok(Token {
+                kind: TrailingComment,
+                value: Value::String(Latin1String::from_utf8_unchecked("this is still a plus")),
+                pos: source.first_substr_pos("--this is still a plus"),
+            }),
+            Ok(Token {
+                kind: LeadingComment,
+                value: Value::String(Latin1String::from_utf8_unchecked("- this is not a minus")),
+                pos: source.first_substr_pos("--- this is not a minus"),
+            }),
+            Ok(Token {
+                kind: LeadingComment,
+                value: Value::String(Latin1String::from_utf8_unchecked(" Neither is this")),
+                pos: source.first_substr_pos("-- Neither is this"),
+            }),
+            Ok(Token {
+                kind: Minus,
+                value: Value::NoValue,
+                pos: minus_pos,
+            }),
+            Ok(Token {
+                kind: TrailingComment,
+                value: Value::String(Latin1String::from_utf8_unchecked(" this is a minus")),
+                pos: source.first_substr_pos("-- this is a minus"),
+            }),
+            Ok(Token {
+                kind: LeadingComment,
+                value: Value::String(Latin1String::from_utf8_unchecked(
+                    " a comment at the end of the file",
+                )),
+                pos: source.first_substr_pos("-- a comment at the end of the file"),
+            }),
+            Ok(Token {
+                kind: LeadingComment,
+                value: Value::String(Latin1String::from_utf8_unchecked(" and another one")),
+                pos: source.first_substr_pos("-- and another one"),
+            }),
+        ];
         assert_eq!(tokens.len(), expected_tokens.len());
         for (token, expected_token) in tokens.iter().zip(&expected_tokens) {
             assert_eq!(token, expected_token);

--- a/vhdl_parser/src/tokenstream.rs
+++ b/vhdl_parser/src/tokenstream.rs
@@ -5,10 +5,10 @@
 // Copyright (c) 2018, Olof Kraigher olof.kraigher@gmail.com
 
 use crate::ast::Ident;
-use crate::message::{MessageHandler, ParseResult};
-use crate::tokenizer::{kinds_str, Kind, Kind::*, Token, Tokenizer, TokenState, Value};
-use crate::source::SrcPos;
 use crate::latin_1::Latin1String;
+use crate::message::{MessageHandler, ParseResult};
+use crate::source::SrcPos;
+use crate::tokenizer::{kinds_str, Kind, Kind::*, Token, TokenState, Tokenizer, Value};
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct WithComment<T> {
@@ -30,7 +30,7 @@ pub fn combine_comments(
         comment.push(&leading_comment);
     }
     match trailing_comment {
-        None => {},
+        None => {}
         Some(trailing) => {
             if comment.len() > 0 {
                 comment.push_newline();
@@ -39,7 +39,7 @@ pub fn combine_comments(
         }
     }
     match unhandled_comments {
-        None => {},
+        None => {}
         Some(comments) => {
             // FIXME: Some handling should be done here to create warning messages
             // about the unhandled comments.
@@ -60,7 +60,10 @@ pub struct TokenStream {
 
 impl TokenStream {
     pub fn new(tokenizer: Tokenizer) -> TokenStream {
-        TokenStream { tokenizer, unhandled_comments: None}
+        TokenStream {
+            tokenizer,
+            unhandled_comments: None,
+        }
     }
 
     pub fn state(&self) -> TokenState {
@@ -70,23 +73,19 @@ impl TokenStream {
     pub fn set_state(&mut self, state: TokenState) {
         self.tokenizer.set_state(state);
         match &mut self.unhandled_comments {
-            None => {},
-            Some(comments) => {
-                loop {
-                    match comments.last() {
-                        None => {
-                            break
-                        },
-                        Some((comment_pos, _)) => {
-                            if comment_pos.start >= state.start() {
-                                comments.pop();
-                            } else {
-                                break;
-                            }
+            None => {}
+            Some(comments) => loop {
+                match comments.last() {
+                    None => break,
+                    Some((comment_pos, _)) => {
+                        if comment_pos.start >= state.start() {
+                            comments.pop();
+                        } else {
+                            break;
                         }
                     }
                 }
-            }
+            },
         }
     }
 
@@ -118,22 +117,24 @@ impl TokenStream {
             match maybe_token {
                 None => {
                     return Ok(None);
-                },
+                }
                 Some(token) => {
                     match (&token.kind, &token.value) {
-                        (LeadingComment, Value::String(comment)) | (TrailingComment, Value::String(comment)) => {
+                        (LeadingComment, Value::String(comment))
+                        | (TrailingComment, Value::String(comment)) => {
                             match &mut self.unhandled_comments {
                                 None => {
-                                    self.unhandled_comments = Some(vec!((token.pos, comment.clone())));
+                                    self.unhandled_comments =
+                                        Some(vec![(token.pos, comment.clone())]);
                                 }
                                 Some(comments) => {
                                     comments.push((token.pos, comment.clone()));
                                 }
                             };
-                        },
+                        }
                         _ => {
                             return Ok(Some(token));
-                        },
+                        }
                     };
                 }
             }
@@ -244,25 +245,23 @@ impl TokenStream {
     }
 
     pub fn leading_comments(&mut self) -> ParseResult<Vec<Latin1String>> {
-        let mut comments = vec!();
+        let mut comments = vec![];
         loop {
             let state = self.state();
             let maybe_token = self.tokenizer.pop()?;
             match maybe_token {
                 None => {
                     return Ok(comments);
-                },
-                Some(token) => {
-                    match (token.kind, token.value) {
-                        (LeadingComment, Value::String(comment)) => {
-                            comments.push(comment);
-                        },
-                        _ => {
-                            self.set_state(state);
-                            return Ok(comments);
-                        },
-                    }
                 }
+                Some(token) => match (token.kind, token.value) {
+                    (LeadingComment, Value::String(comment)) => {
+                        comments.push(comment);
+                    }
+                    _ => {
+                        self.set_state(state);
+                        return Ok(comments);
+                    }
+                },
             }
         }
     }
@@ -272,17 +271,13 @@ impl TokenStream {
         let maybe_token = self.tokenizer.pop()?;
         match maybe_token {
             None => Ok(None),
-            Some(token) => {
-                match (token.kind, token.value) {
-                    (LeadingComment, Value::String(comment)) => {
-                        Ok(Some(comment))
-                    },
-                    _ => {
-                        self.set_state(state);
-                        Ok(None)
-                    },
+            Some(token) => match (token.kind, token.value) {
+                (LeadingComment, Value::String(comment)) => Ok(Some(comment)),
+                _ => {
+                    self.set_state(state);
+                    Ok(None)
                 }
-            }
+            },
         }
     }
 

--- a/vhdl_parser/src/tokenstream.rs
+++ b/vhdl_parser/src/tokenstream.rs
@@ -10,6 +10,49 @@ use crate::tokenizer::{kinds_str, Kind, Kind::*, Token, Tokenizer, TokenState, V
 use crate::source::SrcPos;
 use crate::latin_1::Latin1String;
 
+#[derive(PartialEq, Clone, Debug)]
+pub struct WithComment<T> {
+    pub item: T,
+    pub comment: Option<Latin1String>,
+}
+
+pub fn combine_comments(
+    leading_comments: Vec<Latin1String>,
+    trailing_comment: Option<Latin1String>,
+    unhandled_comments: Option<Vec<(SrcPos, Latin1String)>>,
+    messages: &mut dyn MessageHandler,
+) -> Option<Latin1String> {
+    let mut comment = Latin1String::empty();
+    for leading_comment in leading_comments {
+        if comment.len() > 0 {
+            comment.push_newline();
+        }
+        comment.push(&leading_comment);
+    }
+    match trailing_comment {
+        None => {},
+        Some(trailing) => {
+            if comment.len() > 0 {
+                comment.push_newline();
+            }
+            comment.push(&trailing);
+        }
+    }
+    match unhandled_comments {
+        None => {},
+        Some(comments) => {
+            // FIXME: Some handling should be done here to create warning messages
+            // about the unhandled comments.
+            // Requires modifying tests that expect no messages.
+        }
+    }
+    if comment.len() == 0 {
+        None
+    } else {
+        Some(comment)
+    }
+}
+
 pub struct TokenStream {
     pub tokenizer: Tokenizer,
     unhandled_comments: Option<Vec<(SrcPos, Latin1String)>>,

--- a/vhdl_parser/src/type_declaration.rs
+++ b/vhdl_parser/src/type_declaration.rs
@@ -17,7 +17,7 @@ use crate::range::{parse_array_index_constraint, parse_range};
 use crate::subprogram::parse_subprogram_declaration;
 use crate::subtype_indication::parse_subtype_indication;
 use crate::tokenizer::Kind::*;
-use crate::tokenstream::{TokenStream, combine_comments};
+use crate::tokenstream::{combine_comments, TokenStream};
 
 /// LRM 5.2.2 Enumeration types
 fn parse_enumeration_type_definition(stream: &mut TokenStream) -> ParseResult<TypeDefinition> {
@@ -293,8 +293,17 @@ pub fn parse_type_declaration(
     );
     let trailing_comment = stream.trailing_comment()?;
     let unhandled_comments = stream.unhandled_comments();
-    let comment = combine_comments(leading_comments, trailing_comment, unhandled_comments, messages);
-    Ok(TypeDeclaration { ident, def, comment: comment })
+    let comment = combine_comments(
+        leading_comments,
+        trailing_comment,
+        unhandled_comments,
+        messages,
+    );
+    Ok(TypeDeclaration {
+        ident,
+        def,
+        comment: comment,
+    })
 }
 
 #[cfg(test)]
@@ -304,7 +313,6 @@ mod tests {
     use crate::ast::{DiscreteRange, Ident};
     use crate::latin_1::Latin1String;
     use crate::test_util::Code;
-
 
     #[test]
     fn parse_integer_scalar_type_definition() {
@@ -808,10 +816,12 @@ end units;
 
     #[test]
     fn parse_integer_scalar_type_definition_comment_before() {
-        let code = Code::new("
+        let code = Code::new(
+            "
 -- This is a comment.
 type foo is range 0 to 1;
-");
+",
+        );
         let type_decl = TypeDeclaration {
             ident: code.s1("foo").ident(),
             def: TypeDefinition::Integer(code.s1("0 to 1").range()),


### PR DESCRIPTION
This is a rework of the tokenizing of comments.

The 'Tokenizer' now pops LeadingComment and TrailingComment tokens, rather than incorporating the comments into the other tokens.

The 'TokenStream' skips over the token comments during normal operation so that users of TokenStream are not effected by this change.
The 'TokenStream' has new methods of "leading_comments", "trailing_comment" and "unhandled_comments" which allows parsing code access to the comments when required.