### PR TITLE
Fix `parse_real_literal` to accept capital 'E' for exponent

### DIFF
--- a/vhdl_parser/src/tokenizer.rs
+++ b/vhdl_parser/src/tokenizer.rs
@@ -639,11 +639,11 @@ fn parse_exponent(cursor: &mut ByteCursor) -> Result<i32, String> {
             cursor.pop();
             true
         } else {
+            cursor.skip_if(b'+');
             false
         }
     };
 
-    cursor.skip_if(b'+');
 
     let exp = parse_integer(cursor, 10, false)?;
     if negative {
@@ -811,6 +811,9 @@ fn parse_real_literal(buffer: &mut Latin1String, cursor: &mut ByteCursor) -> Res
     while let Some(b) = cursor.peek(0) {
         match b {
             b'e' => {
+                break;
+            }
+            b'E' => {
                 break;
             }
             b'0'..=b'9' | b'a'..=b'd' | b'f' | b'A'..=b'F' | b'.' => {
@@ -1722,7 +1725,7 @@ end entity"
     #[test]
     fn tokenize_real() {
         assert_eq!(
-            kind_value_tokenize("0.1 -2_2.3_3 2.0e3 3.33E2 2.1e-2 4.4e+1"),
+            kind_value_tokenize("0.1 -2_2.3_3 2.0e3 3.33E2 2.1e-2 4.4e+1 2.5E+3"),
             vec![
                 (
                     AbstractLiteral,
@@ -1748,6 +1751,10 @@ end entity"
                 (
                     AbstractLiteral,
                     Value::AbstractLiteral(ast::AbstractLiteral::Real(44.0))
+                ),
+                (
+                    AbstractLiteral,
+                    Value::AbstractLiteral(ast::AbstractLiteral::Real(2500.0))
                 )
             ]
         );

--- a/vhdl_parser/src/tokenizer.rs
+++ b/vhdl_parser/src/tokenizer.rs
@@ -644,7 +644,6 @@ fn parse_exponent(cursor: &mut ByteCursor) -> Result<i32, String> {
         }
     };
 
-
     let exp = parse_integer(cursor, 10, false)?;
     if negative {
         if exp <= (-(i32::min_value() as i64)) as u64 {


### PR DESCRIPTION
The function `parse_real_literal()` now also correctly parses real literals such as 2.5E+3. A corresponding test case has been added.

In addition, the '+' in the exponent is only skipped if it is not preceeded by a '-'.

This fixes the parsing of reals reported in issue #36.