### PR TITLE
Use absolute path in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ RUN cargo build --package $CRATE --release
 
 FROM scratch
 ARG CRATE
-COPY --from=builder /volume/target/x86_64-unknown-linux-musl/release/$CRATE ./app
-ENTRYPOINT ["./app"]
+COPY --from=builder /volume/target/x86_64-unknown-linux-musl/release/$CRATE /app
+ENTRYPOINT ["/app"]


### PR DESCRIPTION
This PR was triggered by a comment by @Bochlin in Gitter which stated a problem with the current Docker image. It uses a relative path for the application, which prevents users from setting a different working directory. This modification allows running the containers with different workdirs.