### PR TITLE
Add loading of packaged libraries by feature flag

### DIFF
--- a/.github/workflows/build-test-all.yml
+++ b/.github/workflows/build-test-all.yml
@@ -42,13 +42,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --package ${{ matrix.crate }} --release --target ${{ matrix.target }}
+          args: --manifest-path ${{ matrix.crate }}/Cargo.toml --release --target ${{ matrix.target }} --features "packaged"
 
       - name: Test ${{ matrix.crate }}
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --package ${{ matrix.crate }} --release --target ${{ matrix.target }}
+          args: --manifest-path ${{ matrix.crate }}/Cargo.toml --release --target ${{ matrix.target }} --features "packaged"
 
       - name: rustfmt
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'

--- a/vhdl_ls/Cargo.toml
+++ b/vhdl_ls/Cargo.toml
@@ -26,3 +26,7 @@ env_logger = "0.6.0"
 [dev-dependencies]
 tempfile = "^3"
 pretty_assertions = "^0"
+
+[features]
+default = []
+packaged = ["vhdl_parser/packaged"]

--- a/vhdl_parser/Cargo.toml
+++ b/vhdl_parser/Cargo.toml
@@ -27,3 +27,7 @@ parking_lot = "^0"
 tempfile = "^3"
 pretty_assertions = "^0"
 assert_matches = "^1"
+
+[features]
+default = []
+packaged = []


### PR DESCRIPTION
From #45:

> I refactored the configuration loading to make it easy to add loading of installed configuration: See: https://github.com/kraigher/rust_hdl/blob/master/vhdl_parser/src/config.rs#L236-L239
> You only need to add a `load_installed_config` there to implement it.

I've implemented this function. I'm only up to chapter 5 in the Rust book, so improvements are welcome!

I've not added any tests. Am I right in thinking there's none for the other configuration loading functions either? I'm also couldn't work out how you add tests for whether a feature flag is enabled or not anyway.

> I think we should use the `cfg!` macro or attribute to set the relative path to the installed `vhdl_ls.toml` file. By default it think the relative path should assume the binary ends up in `target/release` such that when building locally with `cargo build --release` during development it will just work without having to create the installed folder structure.
> 
> When building for release we can set a `--cfg` clag to `rustc` (https://doc.rust-lang.org/rustc/command-line-arguments.html#--cfg-configure-the-compilation-environment) such that the relative path is according to the install folder format.

I was a bit less successful here. From reading up on this the supported way of doing this with Cargo seems to be through feature flags. I implemented that for the `vhdl_parser` project with the `packaged` feature, which is also added to the `vhdl_ls` project to pass it through.

While this seems to be working for building it locally to the project
```
rust_hdl\vhdl_parser> cargo build --features "packaged"
```
It looks like [feature flags aren't supported](https://github.com/rust-lang/cargo/issues/5015) when building at the workspace level at the moment. The CI build could build from within each folder separately, but that's not what it does now.


