### PR TITLE
Move Docker image build and deploy to Github Action workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
+.git
+.github
 Dockerfile
+example_project
+target
+vhdl_libraries

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,29 @@
+name: Docker
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - '**'
+
+jobs:
+  publish:
+    name: Publish
+    strategy:
+      matrix:
+        crate:
+        - vhdl_parser
+        - vhdl_ls
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: jerray/publish-docker-action@v1.0.3
+      env:
+        CRATE: ${{ matrix.crate }}
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: kraigher/${{ matrix.crate }}
+        auto_tag: true
+        build_args: CRATE

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,20 +22,9 @@ script:
   - cargo build --package $CRATE
   - cargo test --package $CRATE
 
-before_deploy:
-  - docker build -t kraigher/$CRATE:${TRAVIS_TAG:-latest} --build-arg RUST_VERSION=$TRAVIS_RUST_VERSION --build-arg CRATE=$CRATE .
-  - echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-
 deploy:
   - provider: script
     script: cd $CRATE && cargo publish --token "${CRATES_IO_TOKEN}" || true
-    on:
-      rust: stable
-      branch: master
-
-  # @TODO create tag after release
-  - provider: script
-    script: docker push kraigher/$CRATE:${TRAVIS_TAG:-latest}
     on:
       rust: stable
       branch: master


### PR DESCRIPTION
This moves the Docker image build and deploy workflow to Github Actions. This workflow runs for pushed tags and pushes to master (the image with the `latest` tag).

I removed the Docker build and deploy steps from Travis.

@kraigher you'll have to set the `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets for this to work.