### PR TITLE
Add matching case

### DIFF
--- a/vhdl_lang/src/analysis/sequential.rs
+++ b/vhdl_lang/src/analysis/sequential.rs
@@ -107,7 +107,8 @@ impl<'a> AnalyzeContext<'a> {
                 }
             }
             SequentialStatement::Case(ref mut case_stmt) => {
-                let Selection {
+                let CaseStatement {
+                    is_matching: _,
                     expression,
                     alternatives,
                 } = case_stmt;

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -781,7 +781,12 @@ pub struct Selection<T> {
 }
 
 /// LRM 10.9 Case statement
-pub type CaseStatement = Selection<Vec<LabeledSequentialStatement>>;
+#[derive(PartialEq, Debug, Clone)]
+pub struct CaseStatement {
+    pub is_matching: bool,
+    pub expression: WithPos<Expression>,
+    pub alternatives: Vec<Alternative<Vec<LabeledSequentialStatement>>>,
+}
 
 /// LRM 10.10 Loop statement
 #[derive(PartialEq, Debug, Clone)]

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -276,7 +276,7 @@ impl Search for LabeledSequentialStatement {
                 return_if_found!(condition.search(searcher));
             }
             SequentialStatement::Case(ref case_stmt) => {
-                return_if_found!(search_selection(case_stmt, false, searcher));
+                return_if_found!(case_stmt.search(searcher));
             }
             SequentialStatement::Loop(ref loop_stmt) => {
                 let LoopStatement {
@@ -1020,6 +1020,19 @@ impl Search for ContextDeclaration {
         return_if_finished!(searcher.search_source(self.source()));
         return_if_found!(searcher.search_decl_pos(self.ident().pos()).or_not_found());
         self.items.search(searcher)
+    }
+}
+
+impl Search for CaseStatement {
+    fn search(&self, searcher: &mut impl Searcher) -> SearchResult {
+        let CaseStatement {
+            is_matching: _,
+            expression,
+            alternatives,
+        } = self;
+        return_if_found!(expression.search(searcher));
+        return_if_found!(search_alternatives(alternatives, false, searcher));
+        NotFound
     }
 }
 

--- a/vhdl_lang/src/syntax/sequential_statement.rs
+++ b/vhdl_lang/src/syntax/sequential_statement.rs
@@ -1354,14 +1354,10 @@ end case?;
                 None,
                 SequentialStatement::Case(CaseStatement {
                     expression: code.s1("foo(1)").expr(),
-                    alternatives: vec![
-                        Alternative {
-                            choices: code.s1("others").choices(),
-                            item: vec![
-                                code.s1("null;").sequential_statement(),
-                            ]
-                        }
-                    ],
+                    alternatives: vec![Alternative {
+                        choices: code.s1("others").choices(),
+                        item: vec![code.s1("null;").sequential_statement(),]
+                    }],
                 })
             )
         );

--- a/vhdl_lang/src/syntax/sequential_statement.rs
+++ b/vhdl_lang/src/syntax/sequential_statement.rs
@@ -179,6 +179,7 @@ fn parse_case_statement_known_keyword(
 
     stream.expect_kind(SemiColon)?;
     Ok(CaseStatement {
+        is_matching,
         expression,
         alternatives,
     })
@@ -1317,6 +1318,7 @@ end case;
             with_label(
                 None,
                 SequentialStatement::Case(CaseStatement {
+                    is_matching: false,
                     expression: code.s1("foo(1)").expr(),
                     alternatives: vec![
                         Alternative {
@@ -1353,6 +1355,7 @@ end case?;
             with_label(
                 None,
                 SequentialStatement::Case(CaseStatement {
+                    is_matching: true,
                     expression: code.s1("foo(1)").expr(),
                     alternatives: vec![Alternative {
                         choices: code.s1("others").choices(),

--- a/vhdl_lang/src/syntax/tokens/tokenizer.rs
+++ b/vhdl_lang/src/syntax/tokens/tokenizer.rs
@@ -1533,9 +1533,7 @@ impl<'a> Tokenizer<'a> {
                             (QueGT, Value::NoValue)
                         }
                     }
-                    _ => {
-                        (Que, Value::NoValue)
-                    }
+                    _ => (Que, Value::NoValue),
                 }
             }
             b'^' => {

--- a/vhdl_lang/src/syntax/tokens/tokenizer.rs
+++ b/vhdl_lang/src/syntax/tokens/tokenizer.rs
@@ -132,6 +132,7 @@ pub enum Kind {
     QueLTE,
     QueGT,
     QueGTE,
+    Que,
 
     Times,
     Pow,
@@ -334,6 +335,7 @@ pub fn kind_str(kind: Kind) -> &'static str {
         QueLTE => &"?<=",
         QueGT => &"?>",
         QueGTE => &"?>=",
+        Que => &"?",
 
         Times => &"*",
         Pow => &"**",
@@ -1532,7 +1534,7 @@ impl<'a> Tokenizer<'a> {
                         }
                     }
                     _ => {
-                        illegal_token!();
+                        (Que, Value::NoValue)
                     }
                 }
             }
@@ -2276,8 +2278,8 @@ end entity"
     #[test]
     fn tokenize_questionmark_cmp() {
         assert_eq!(
-            kinds_tokenize("?< ?<= ?> ?>= ??"),
-            vec![QueLT, QueLTE, QueGT, QueGTE, QueQue]
+            kinds_tokenize("? ?< ?<= ?> ?>= ??"),
+            vec![Que, QueLT, QueLTE, QueGT, QueGTE, QueQue]
         );
     }
 
@@ -2436,7 +2438,7 @@ comment
 
     #[test]
     fn tokenize_illegal() {
-        let code = Code::new("begin?end");
+        let code = Code::new("begin!end");
         let (tokens, _) = code.tokenize_result();
         assert_eq!(
             tokens,
@@ -2448,7 +2450,7 @@ comment
                     next_state: state_at_end(&code.s1("begin")),
                     comments: None,
                 }),
-                Err(Diagnostic::error(&code.s1("?"), "Illegal token")),
+                Err(Diagnostic::error(&code.s1("!"), "Illegal token")),
                 Ok(Token {
                     kind: End,
                     value: Value::NoValue,


### PR DESCRIPTION
Work in progress to add matching case statement.

Added tokenization of '?' and updated parsing of case statement to support matching case.
```
case? expr is
    when "--00" => null;
    when others => null;
end case?;
```

This update removes the error thrown by the parser but does not store in the AST that it is a matching case statement. My suggestion is to add a `is_matching: bool` element to the `ast::Selection` struct.

@kraigher Any comments?
