### PR TITLE
Allow publish actions only from main repo

### DIFF
--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     name: Publish
+    if: $GITHUB_REPOSITORY == kraigher/rust_hdl
     strategy:
       matrix:
         crate:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   publish:
     name: Publish
+    if: $GITHUB_REPOSITORY == kraigher/rust_hdl
     strategy:
       matrix:
         crate:


### PR DESCRIPTION
Currently `Docker` action fails on pushing to forked repos (`Crates.io` would also fail on a publishig a tag). This adds a check on the actions so that they only act on the main repo to stop actions failing in forks.