### PR TITLE
Add block_header and analyze guard_condition

### DIFF
--- a/vhdl_lang/src/analysis/concurrent.rs
+++ b/vhdl_lang/src/analysis/concurrent.rs
@@ -39,7 +39,22 @@ impl<'a> AnalyzeContext<'a> {
 
         match statement.statement {
             ConcurrentStatement::Block(ref mut block) => {
+                if let Some(ref mut guard_condition) = block.guard_condition {
+                    self.analyze_expression(parent, guard_condition, diagnostics)?;
+                }
                 let mut region = parent.nested();
+                if let Some(ref mut list) = block.header.generic_clause {
+                    self.analyze_interface_list(&mut region, list, diagnostics)?;
+                }
+                if let Some(ref mut list) = block.header.generic_map {
+                    self.analyze_assoc_elems(parent, list, diagnostics)?;
+                }
+                if let Some(ref mut list) = block.header.port_clause {
+                    self.analyze_interface_list(&mut region, list, diagnostics)?;
+                }
+                if let Some(ref mut list) = block.header.port_map {
+                    self.analyze_assoc_elems(parent, list, diagnostics)?;
+                }
                 self.analyze_declarative_part(&mut region, &mut block.decl, diagnostics)?;
                 self.analyze_concurrent_part(&mut region, &mut block.statements, diagnostics)?;
             }

--- a/vhdl_lang/src/analysis/tests/resolves_names.rs
+++ b/vhdl_lang/src/analysis/tests/resolves_names.rs
@@ -1046,3 +1046,33 @@ end architecture;
 ",
     );
 }
+
+#[test]
+fn block_names_are_visible() {
+    check_code_with_no_diagnostics(
+        "
+entity ent is
+  port (ent_in : integer);
+end entity;
+
+architecture a of ent is
+  signal sig : integer;
+begin
+  blk: block (ent_in = 1) is
+    generic( gen : integer := 0 );
+    generic map ( gen => 1);
+    port( 
+      prt_in : in integer := 0;
+      prt_out : out integer := 0
+    );
+    port map (
+      prt_in => ent_in + sig,
+      prt_out => open
+    );
+  begin
+    prt_out <= gen + prt_in + sig;
+  end block;
+end architecture;
+",
+    );
+}

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -853,8 +853,18 @@ pub struct LabeledSequentialStatement {
 #[derive(PartialEq, Debug, Clone)]
 pub struct BlockStatement {
     pub guard_condition: Option<WithPos<Expression>>,
+    pub header: BlockHeader,
     pub decl: Vec<Declaration>,
     pub statements: Vec<LabeledConcurrentStatement>,
+}
+
+/// LRM 11.2 Block statement
+#[derive(PartialEq, Debug, Clone)]
+pub struct BlockHeader {
+    pub generic_clause: Option<Vec<InterfaceDeclaration>>,
+    pub generic_map: Option<Vec<AssociationElement>>,
+    pub port_clause: Option<Vec<InterfaceDeclaration>>,
+    pub port_map: Option<Vec<AssociationElement>>,
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/vhdl_lang/src/syntax/concurrent_statement.rs
+++ b/vhdl_lang/src/syntax/concurrent_statement.rs
@@ -51,7 +51,7 @@ pub fn parse_block_statement(
     stream.expect_kind(SemiColon)?;
     Ok(BlockStatement {
         guard_condition,
-        header: header,
+        header,
         decl,
         statements,
     })

--- a/vhdl_lang/src/syntax/concurrent_statement.rs
+++ b/vhdl_lang/src/syntax/concurrent_statement.rs
@@ -61,7 +61,6 @@ fn parse_block_header(
     stream: &mut TokenStream,
     diagnostics: &mut dyn DiagnosticHandler,
 ) -> ParseResult<BlockHeader> {
-
     let mut generic_clause = None;
     let mut generic_map = None;
     let mut port_clause = None;

--- a/vhdl_lang/src/syntax/concurrent_statement.rs
+++ b/vhdl_lang/src/syntax/concurrent_statement.rs
@@ -9,6 +9,7 @@ use super::common::ParseResult;
 use super::declarative_part::{is_declarative_part, parse_declarative_part};
 use super::expression::parse_aggregate_leftpar_known;
 use super::expression::{parse_choices, parse_expression};
+use super::interface_declaration::{parse_generic_interface_list, parse_port_interface_list};
 use super::names::{
     expression_to_ident, into_selected_name, parse_association_list, parse_name_initial_token,
     parse_selected_name,
@@ -31,10 +32,6 @@ pub fn parse_block_statement(
     let token = stream.peek_expect()?;
     let guard_condition = {
         match token.kind {
-            Is => {
-                stream.move_after(&token);
-                None
-            }
             LeftPar => {
                 stream.move_after(&token);
                 let expr = parse_expression(stream)?;
@@ -44,6 +41,8 @@ pub fn parse_block_statement(
             _ => None,
         }
     };
+    stream.pop_if_kind(Is)?;
+    let header = parse_block_header(stream, diagnostics)?;
     let decl = parse_declarative_part(stream, diagnostics, true)?;
     let statements = parse_labeled_concurrent_statements(stream, diagnostics)?;
     stream.expect_kind(Block)?;
@@ -52,8 +51,111 @@ pub fn parse_block_statement(
     stream.expect_kind(SemiColon)?;
     Ok(BlockStatement {
         guard_condition,
+        header: header,
         decl,
         statements,
+    })
+}
+
+fn parse_block_header(
+    stream: &mut TokenStream,
+    diagnostics: &mut dyn DiagnosticHandler,
+) -> ParseResult<BlockHeader> {
+    let mut has_port_clause = false;
+    let mut has_port_map = false;
+    let mut has_generic_clause = false;
+    let mut has_generic_map = false;
+
+    let mut generic_clause = None;
+    let mut generic_map = None;
+    let mut port_clause = None;
+    let mut port_map = None;
+
+    loop {
+        let token = stream.peek_expect()?;
+        match token.kind {
+            Generic => {
+                stream.move_after(&token);
+                if let Some(map_token) = stream.pop_if_kind(Map)? {
+                    has_generic_map = true;
+                    if has_port_clause || has_port_map {
+                        diagnostics.push(Diagnostic::error(
+                            map_token,
+                            "Generic map must come before port clause and port map",
+                        ));
+                    } else if !has_generic_clause {
+                        diagnostics.push(Diagnostic::error(
+                            map_token,
+                            "Generic map declared without preceeding generic clause",
+                        ));
+                    } else if generic_map.is_some() {
+                        diagnostics.push(Diagnostic::error(map_token, "Duplicate generic map"));
+                    }
+                    let parsed_generic_map = Some(parse_association_list(stream)?);
+                    stream.expect_kind(SemiColon)?;
+                    if generic_map.is_none() {
+                        generic_map = parsed_generic_map;
+                    }
+                } else {
+                    has_generic_clause = true;
+                    if has_generic_map {
+                        diagnostics.push(Diagnostic::error(
+                            token,
+                            "Generic clause must come before generic map",
+                        ));
+                    } else if generic_clause.is_some() {
+                        diagnostics.push(Diagnostic::error(token, "Duplicate generic clause"));
+                    }
+                    let parsed_generic_list = parse_generic_interface_list(stream, diagnostics)?;
+                    stream.expect_kind(SemiColon)?;
+                    if generic_clause.is_none() {
+                        generic_clause = Some(parsed_generic_list);
+                    }
+                }
+            }
+            Port => {
+                stream.move_after(&token);
+                if let Some(map_token) = stream.pop_if_kind(Map)? {
+                    has_port_map = true;
+                    if !has_port_clause {
+                        diagnostics.push(Diagnostic::error(
+                            map_token,
+                            "Port map declared without preceeding port clause",
+                        ));
+                    } else if port_map.is_some() {
+                        diagnostics.push(Diagnostic::error(map_token, "Duplicate port map"));
+                    }
+                    let parsed_port_map = Some(parse_association_list(stream)?);
+                    stream.expect_kind(SemiColon)?;
+                    if port_map.is_none() {
+                        port_map = parsed_port_map;
+                    }
+                } else {
+                    has_port_clause = true;
+                    if has_port_map {
+                        diagnostics.push(Diagnostic::error(
+                            token,
+                            "Port clause declared after port map",
+                        ));
+                    } else if port_clause.is_some() {
+                        diagnostics.push(Diagnostic::error(token, "Duplicate port clause"));
+                    }
+                    let parsed_port_list = parse_port_interface_list(stream, diagnostics)?;
+                    stream.expect_kind(SemiColon)?;
+                    if port_clause.is_none() {
+                        port_clause = Some(parsed_port_list);
+                    }
+                }
+            }
+            _ => break,
+        }
+    }
+
+    Ok(BlockHeader {
+        generic_clause,
+        generic_map,
+        port_clause,
+        port_map,
     })
 }
 
@@ -687,6 +789,12 @@ end block;
 
         let block = BlockStatement {
             guard_condition: None,
+            header: BlockHeader {
+                generic_clause: None,
+                generic_map: None,
+                port_clause: None,
+                port_map: None,
+            },
             decl: code.s1("constant const : natural := 0;").declarative_part(),
             statements: vec![LabeledConcurrentStatement {
                 label: Some(code.s1("name2").ident()),
@@ -709,6 +817,12 @@ end block name;
         );
         let block = BlockStatement {
             guard_condition: None,
+            header: BlockHeader {
+                generic_clause: None,
+                generic_map: None,
+                port_clause: None,
+                port_map: None,
+            },
             decl: vec![],
             statements: vec![],
         };
@@ -728,6 +842,66 @@ end block;
         );
         let block = BlockStatement {
             guard_condition: Some(code.s1("cond = true").expr()),
+            header: BlockHeader {
+                generic_clause: None,
+                generic_map: None,
+                port_clause: None,
+                port_map: None,
+            },
+            decl: vec![],
+            statements: vec![],
+        };
+        let stmt = code.with_stream_no_diagnostics(parse_labeled_concurrent_statement);
+        assert_eq!(stmt.label, Some(code.s1("name").ident()));
+        assert_eq!(stmt.statement, ConcurrentStatement::Block(block));
+    }
+
+    #[test]
+    fn test_guarded_block_variant() {
+        let code = Code::new(
+            "\
+name : block (cond = true) is
+begin
+end block;
+",
+        );
+        let block = BlockStatement {
+            guard_condition: Some(code.s1("cond = true").expr()),
+            header: BlockHeader {
+                generic_clause: None,
+                generic_map: None,
+                port_clause: None,
+                port_map: None,
+            },
+            decl: vec![],
+            statements: vec![],
+        };
+        let stmt = code.with_stream_no_diagnostics(parse_labeled_concurrent_statement);
+        assert_eq!(stmt.label, Some(code.s1("name").ident()));
+        assert_eq!(stmt.statement, ConcurrentStatement::Block(block));
+    }
+
+    #[test]
+    fn test_block_header() {
+        let code = Code::new(
+            "\
+name: block is
+  generic(gen: integer := 1);
+  generic map(gen => 1);
+  port(prt: integer := 1);
+  port map(prt => 2);
+begin
+end block;
+",
+        );
+        let block = BlockStatement {
+            guard_condition: None,
+            header: BlockHeader {
+                generic_clause: Some(vec![code.s1("gen: integer := 1").generic()]),
+                generic_map: Some(code.s1("(gen => 1)").association_list()),
+                port_clause: Some(vec![code.s1("prt: integer := 1").port()]),
+                port_map: Some(code.s1("(prt => 2)").association_list()),
+            },
             decl: vec![],
             statements: vec![],
         };


### PR DESCRIPTION
Updates for `block_statement`:
- Parsing and analysis of `block_header`
- Fix error when optional `is` is used after `guard_condition`
- Analysis of `guard_condition`