### PR TITLE
Allow multiple '^' in relative external name

### DIFF
--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -117,7 +117,9 @@ pub enum ExternalObjectClass {
 pub enum ExternalPath {
     Package(WithPos<Name>),
     Absolute(WithPos<Name>),
-    Relative(WithPos<Name>),
+
+    // usize field indicates the number of up-levels ('^')
+    Relative(WithPos<Name>, usize),
 }
 
 /// LRM 8.7 External names


### PR DESCRIPTION
Fixes parsing error when multiple "up-levels" are present in external name e.g.  
`<< signal ^.^.^.dut.gen(0) : std_logic >>`  

The number of up-levels are not stored and a TODO comment is added. The number up up-levels are required if elaboration checks are implemented as the hierarchy of the design must be known.