### PR TITLE
Add version info to vhdl_ls

### DIFF
--- a/vhdl_ls/Cargo.toml
+++ b/vhdl_ls/Cargo.toml
@@ -22,6 +22,7 @@ lsp-types = "^0.63"
 fnv = "^1"
 log = "0.4.6"
 env_logger = "0.6.0"
+clap = "^2"
 
 [dev-dependencies]
 tempfile = "^3"

--- a/vhdl_ls/src/main.rs
+++ b/vhdl_ls/src/main.rs
@@ -11,6 +11,14 @@ extern crate log;
 use env_logger;
 
 fn main() {
+    use clap::App;
+
+    let _matches = App::new(env!("CARGO_PKG_NAME"))
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about(env!("CARGO_PKG_DESCRIPTION"))
+        .get_matches();
+
     env_logger::init();
     info!("Starting language server");
     vhdl_ls::start();


### PR DESCRIPTION
For the release process it would be good to be able to check the version of the `vhdl_ls` binary.

At the moment the language server crashes with any command line arguments:
```
>target\debug\vhdl_ls.exe --version

thread '<unnamed>' panicked at 'explicit panic', vhdl_ls\src\stdio_server.rs:192:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

This uses `clap` like `vhdl_lang`.