### PR TITLE
WIP: Outline concept ("textDocument/documentSymbol")

### DIFF
--- a/vhdl_lang/src/analysis/design_unit.rs
+++ b/vhdl_lang/src/analysis/design_unit.rs
@@ -462,10 +462,10 @@ impl<'a> AnalyzeContext<'a> {
     fn analyze_context_clause(
         &self,
         region: &mut Region<'_>,
-        context_clause: &mut [WithPos<ContextItem>],
+        context_clause: &mut ContextClause,
         diagnostics: &mut dyn DiagnosticHandler,
     ) -> FatalNullResult {
-        for context_item in context_clause.iter_mut() {
+        for context_item in context_clause.items.iter_mut() {
             match context_item.item {
                 ContextItem::Library(LibraryClause { ref name_list }) => {
                     for library_name in name_list.iter() {

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -1104,6 +1104,8 @@ pub struct EntityDeclaration {
     pub port_clause: Option<Vec<InterfaceDeclaration>>,
     pub decl: Vec<Declaration>,
     pub statements: Vec<LabeledConcurrentStatement>,
+    // Non-LRM
+    pub pos: Option<SrcPos>, //@TODO: Probably not option Full range of the design unit
 }
 /// LRM 3.3 Architecture bodies
 #[derive(PartialEq, Debug, Clone)]
@@ -1161,7 +1163,21 @@ pub enum AnySecondaryUnit {
     PackageBody(PackageBody),
 }
 
-pub type ContextClause = Vec<WithPos<ContextItem>>;
+#[derive(PartialEq, Debug, Clone)]
+pub struct ContextClause {
+    pub items: Vec<WithPos<ContextItem>>,
+    // Non-LRM
+    pub pos: Option<SrcPos>,
+}
+
+impl std::default::Default for ContextClause {
+    fn default() -> ContextClause {
+        ContextClause {
+            items: vec![],
+            pos: None,
+        }
+    }
+}
 
 /// LRM 13.1 Design units
 #[derive(PartialEq, Debug, Clone)]

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -940,6 +940,12 @@ impl Search for WithPos<ContextItem> {
     }
 }
 
+impl Search for ContextClause {
+    fn search(&self, searcher: &mut impl Searcher) -> SearchResult {
+        self.items.search(searcher)
+    }
+}
+
 impl Search for AnyDesignUnit {
     fn search(&self, searcher: &mut impl Searcher) -> SearchResult {
         delegate_any!(self, unit, unit.search(searcher))

--- a/vhdl_lang/src/project.rs
+++ b/vhdl_lang/src/project.rs
@@ -98,6 +98,20 @@ impl Project {
         project
     }
 
+    pub fn parse_design_file(&self, file_name: &Path) -> Option<DesignFile> {
+        let mut diagnostics = vec![];
+        match self.parser.parse_design_file(file_name, &mut diagnostics) {
+            Ok((_, design_file)) => Some(design_file),
+            Err(_) => None,
+        }
+    }
+
+    pub fn get_design_file(&self, file_name: &Path) -> Option<DesignFile> {
+        self.files
+            .get(file_name)
+            .map(|file| file.design_file.clone())
+    }
+
     pub fn get_source(&self, file_name: &Path) -> Option<Source> {
         self.files.get(file_name).map(|file| file.source.clone())
     }

--- a/vhdl_lang/src/syntax/context.rs
+++ b/vhdl_lang/src/syntax/context.rs
@@ -116,7 +116,7 @@ pub fn parse_context(
 
         Ok(DeclarationOrReference::Declaration(ContextDeclaration {
             ident,
-            items,
+            items: ContextClause { items, pos: None },
         }))
     } else {
         // Context reference
@@ -252,7 +252,7 @@ end context ident;
                 code.with_stream_no_diagnostics(parse_context),
                 DeclarationOrReference::Declaration(ContextDeclaration {
                     ident: code.s1("ident").ident(),
-                    items: vec![]
+                    items: ContextClause::default()
                 })
             );
         }
@@ -278,7 +278,7 @@ end context ident2;
             context,
             DeclarationOrReference::Declaration(ContextDeclaration {
                 ident: code.s1("ident").ident(),
-                items: vec![]
+                items: ContextClause::default()
             })
         );
     }
@@ -298,26 +298,29 @@ end context;
             code.with_stream_no_diagnostics(parse_context),
             DeclarationOrReference::Declaration(ContextDeclaration {
                 ident: code.s1("ident").ident(),
-                items: vec![
-                    WithPos::new(
-                        ContextItem::Library(LibraryClause {
-                            name_list: vec![code.s1("foo").ident()]
-                        }),
-                        code.s1("library foo;")
-                    ),
-                    WithPos::new(
-                        ContextItem::Use(UseClause {
-                            name_list: vec![code.s1("foo.bar").name()]
-                        }),
-                        code.s1("use foo.bar;")
-                    ),
-                    WithPos::new(
-                        ContextItem::Context(ContextReference {
-                            name_list: vec![code.s1("foo.ctx").name()]
-                        }),
-                        code.s1("context foo.ctx;")
-                    ),
-                ]
+                items: ContextClause {
+                    items: vec![
+                        WithPos::new(
+                            ContextItem::Library(LibraryClause {
+                                name_list: vec![code.s1("foo").ident()]
+                            }),
+                            code.s1("library foo;")
+                        ),
+                        WithPos::new(
+                            ContextItem::Use(UseClause {
+                                name_list: vec![code.s1("foo.bar").name()]
+                            }),
+                            code.s1("use foo.bar;")
+                        ),
+                        WithPos::new(
+                            ContextItem::Context(ContextReference {
+                                name_list: vec![code.s1("foo.ctx").name()]
+                            }),
+                            code.s1("context foo.ctx;")
+                        ),
+                    ],
+                    pos: None
+                }
             })
         )
     }

--- a/vhdl_ls/src/document_symbol.rs
+++ b/vhdl_ls/src/document_symbol.rs
@@ -1,0 +1,379 @@
+use lsp_types::{DocumentSymbol, SymbolKind};
+use vhdl_lang::ast::*;
+
+pub trait HasDocumentSymbol {
+    fn document_symbol(&self) -> DocumentSymbol;
+}
+
+impl HasDocumentSymbol for AnyDesignUnit {
+    fn document_symbol(&self) -> DocumentSymbol {
+        match self {
+            AnyDesignUnit::Primary(ref unit) => unit.document_symbol(),
+            AnyDesignUnit::Secondary(ref unit) => unit.document_symbol(),
+        }
+    }
+}
+
+impl HasDocumentSymbol for AnyPrimaryUnit {
+    fn document_symbol(&self) -> DocumentSymbol {
+        match self {
+            AnyPrimaryUnit::Entity(ref unit) => unit.document_symbol(),
+            AnyPrimaryUnit::Configuration(ref unit) => unit.document_symbol(),
+            AnyPrimaryUnit::Package(ref unit) => unit.document_symbol(),
+            AnyPrimaryUnit::PackageInstance(ref unit) => unit.document_symbol(),
+            AnyPrimaryUnit::Context(ref unit) => unit.document_symbol(),
+        }
+    }
+}
+
+impl HasDocumentSymbol for AnySecondaryUnit {
+    fn document_symbol(&self) -> DocumentSymbol {
+        match self {
+            AnySecondaryUnit::PackageBody(ref unit) => unit.document_symbol(),
+            AnySecondaryUnit::Architecture(ref unit) => unit.document_symbol(),
+        }
+    }
+}
+
+impl HasDocumentSymbol for EntityDeclaration {
+    fn document_symbol(&self) -> DocumentSymbol {
+        let mut children = Vec::new();
+        if let Some(ref generics) = self.generic_clause {
+            let mut symbol = generics.document_symbol();
+            symbol.name = String::from("Generics");
+            symbol.kind = SymbolKind::Array;
+            children.push(symbol);
+        }
+        if let Some(ref ports) = self.port_clause {
+            let mut symbol = ports.document_symbol();
+            symbol.name = String::from("Ports");
+            symbol.kind = SymbolKind::Struct;
+            children.push(symbol);
+        }
+
+        DocumentSymbol {
+            name: self.ident.item.name_utf8(),
+            detail: Some(String::from("Entity")),
+            kind: SymbolKind::Interface,
+            deprecated: None,
+            range: {
+                if let Some(ref pos) = self.pos {
+                    to_lsp_range(pos.range())
+                } else {
+                    to_lsp_range(self.ident.pos.range())
+                }
+            },
+            selection_range: to_lsp_range(self.ident.pos.range()),
+            children: none_if_empty(children),
+        }
+    }
+}
+
+impl HasDocumentSymbol for ConfigurationDeclaration {
+    fn document_symbol(&self) -> DocumentSymbol {
+        DocumentSymbol {
+            name: self.ident.item.name_utf8(),
+            detail: Some(String::from("Configuration")),
+            kind: SymbolKind::Class, // @TODO: Map primary units to diverse SymbolKinds?
+            deprecated: None,
+            // Range should be "full range"
+            range: to_lsp_range(self.ident.pos.range()),
+            selection_range: to_lsp_range(self.ident.pos.range()),
+            children: None,
+        }
+    }
+}
+
+impl HasDocumentSymbol for PackageDeclaration {
+    fn document_symbol(&self) -> DocumentSymbol {
+        DocumentSymbol {
+            name: self.ident.item.name_utf8(),
+            detail: Some(String::from("Package")),
+            kind: SymbolKind::Module, // @TODO: Map primary units to diverse SymbolKinds?
+            deprecated: None,
+            // Range should be "full range"
+            range: to_lsp_range(self.ident.pos.range()),
+            selection_range: to_lsp_range(self.ident.pos.range()),
+            children: None,
+        }
+    }
+}
+
+impl HasDocumentSymbol for PackageInstantiation {
+    fn document_symbol(&self) -> DocumentSymbol {
+        DocumentSymbol {
+            name: self.ident.item.name_utf8(),
+            detail: Some(String::from("Package instance")),
+            kind: SymbolKind::Package, // @TODO: Map primary units to diverse SymbolKinds?
+            deprecated: None,
+            // Range should be "full range"
+            range: to_lsp_range(self.ident.pos.range()),
+            selection_range: to_lsp_range(self.ident.pos.range()),
+            children: None,
+        }
+    }
+}
+
+impl HasDocumentSymbol for ContextDeclaration {
+    fn document_symbol(&self) -> DocumentSymbol {
+        DocumentSymbol {
+            name: self.ident.item.name_utf8(),
+            detail: Some(String::from("Context")),
+            kind: SymbolKind::Namespace, // @TODO: Map primary units to diverse SymbolKinds?
+            deprecated: None,
+            // Range should be "full range"
+            range: to_lsp_range(self.ident.pos.range()),
+            selection_range: to_lsp_range(self.ident.pos.range()),
+            children: None,
+        }
+    }
+}
+
+impl HasDocumentSymbol for PackageBody {
+    fn document_symbol(&self) -> DocumentSymbol {
+        DocumentSymbol {
+            name: self.ident.item.item.name_utf8(),
+            detail: Some(String::from("Package body")),
+            kind: SymbolKind::Package,
+            deprecated: None,
+            // Range should be "full range"
+            range: to_lsp_range(self.ident.item.pos.range()),
+            selection_range: to_lsp_range(self.ident.item.pos.range()),
+            children: None,
+        }
+    }
+}
+
+impl HasDocumentSymbol for ArchitectureBody {
+    fn document_symbol(&self) -> DocumentSymbol {
+        DocumentSymbol {
+            name: self.ident.item.name_utf8(),
+            detail: Some(String::from(format!(
+                "Architecture of {}",
+                self.entity_name.item.item.name().to_string()
+            ))),
+            kind: SymbolKind::Class,
+            deprecated: None,
+            // Range should be "full range"
+            range: to_lsp_range(self.ident.pos.range()),
+            selection_range: to_lsp_range(self.ident.pos.range()),
+            children: None,
+        }
+    }
+}
+
+fn interface_declaration_range(interface: &InterfaceDeclaration) -> lsp_types::Range {
+    to_lsp_range({
+        match interface {
+            InterfaceDeclaration::Object(ref object) => object.ident.pos.range(),
+            InterfaceDeclaration::File(ref file) => file.ident.pos.range(),
+            InterfaceDeclaration::Type(ref ident) => ident.pos.range(),
+            InterfaceDeclaration::Subprogram(ref subprogram_declaration, _) => {
+                subprogram_declaration.designator().pos.range()
+            }
+            InterfaceDeclaration::Package(ref package) => package.ident.pos.range(),
+        }
+    })
+}
+
+impl HasDocumentSymbol for ContextClause {
+    fn document_symbol(&self) -> DocumentSymbol {
+        DocumentSymbol {
+            name: String::from("Context clause"),
+            detail: None,
+            kind: SymbolKind::Namespace,
+            deprecated: None,
+            range: to_lsp_range(self.pos.as_ref().unwrap().range()),
+            selection_range: to_lsp_range(self.pos.as_ref().unwrap().range()),
+            children: None,
+        }
+    }
+}
+
+impl HasDocumentSymbol for Vec<InterfaceDeclaration> {
+    fn document_symbol(&self) -> DocumentSymbol {
+        let range = {
+            if let Some(interface) = self.get(0) {
+                lsp_types::Range {
+                    start: interface_declaration_range(interface).start,
+                    end: interface_declaration_range(self.last().unwrap()).end,
+                }
+            } else {
+                lsp_types::Range {
+                    start: lsp_types::Position {
+                        character: 0,
+                        line: 0,
+                    },
+                    end: lsp_types::Position {
+                        character: 0,
+                        line: 0,
+                    },
+                }
+            }
+        };
+
+        DocumentSymbol {
+            name: String::from("Interface declaration"),
+            detail: None,
+            kind: SymbolKind::Namespace,
+            deprecated: None,
+            // Range should be "full range"
+            range: range,
+            selection_range: range,
+            children: none_if_empty(self.iter().map(|i| i.document_symbol()).collect()),
+        }
+    }
+}
+
+impl HasDocumentSymbol for InterfaceDeclaration {
+    fn document_symbol(&self) -> DocumentSymbol {
+        match self {
+            InterfaceDeclaration::Object(ref object) => object.document_symbol(),
+            InterfaceDeclaration::File(ref file) => file.document_symbol(),
+            InterfaceDeclaration::Type(ref ident) => {
+                DocumentSymbol {
+                    name: ident.item.name_utf8(),
+                    detail: Some(String::from("Type")),
+                    kind: SymbolKind::TypeParameter,
+                    deprecated: None,
+                    // Range should be "full range"
+                    range: to_lsp_range(ident.pos.range()),
+                    selection_range: to_lsp_range(ident.pos.range()),
+                    children: None,
+                }
+            }
+            InterfaceDeclaration::Subprogram(ref subprogram_declaration, _) => {
+                subprogram_declaration.document_symbol()
+            }
+            InterfaceDeclaration::Package(ref package) => package.document_symbol(),
+        }
+    }
+}
+
+impl HasDocumentSymbol for InterfaceObjectDeclaration {
+    fn document_symbol(&self) -> DocumentSymbol {
+        DocumentSymbol {
+            name: self.ident.item.name_utf8(),
+            detail: {
+                match self.class {
+                    ObjectClass::Constant => None,
+                    _ => Some(String::from(format!(": {}", mode_to_string(&self.mode)))), // @TODO signal_kind when implemented
+                }
+            },
+            kind: {
+                match self.class {
+                    ObjectClass::Signal => SymbolKind::Field,
+                    ObjectClass::Constant => SymbolKind::Constant,
+                    ObjectClass::Variable => SymbolKind::Variable,
+                    ObjectClass::SharedVariable => SymbolKind::Variable,
+                }
+            },
+            deprecated: None,
+            // Range should be "full range"
+            range: to_lsp_range(self.ident.pos.range()),
+            selection_range: to_lsp_range(self.ident.pos.range()),
+            children: None,
+        }
+    }
+}
+
+impl HasDocumentSymbol for InterfaceFileDeclaration {
+    fn document_symbol(&self) -> DocumentSymbol {
+        DocumentSymbol {
+            name: self.ident.item.name_utf8(),
+            detail: Some(String::from("File")),
+            kind: SymbolKind::File,
+            deprecated: None,
+            // Range should be "full range"
+            range: to_lsp_range(self.ident.pos.range()),
+            selection_range: to_lsp_range(self.ident.pos.range()),
+            children: None,
+        }
+    }
+}
+
+impl HasDocumentSymbol for SubprogramDeclaration {
+    fn document_symbol(&self) -> DocumentSymbol {
+        match self {
+            SubprogramDeclaration::Procedure(procedure) => DocumentSymbol {
+                name: match procedure.designator.item {
+                    SubprogramDesignator::Identifier(ref symbol) => symbol.name_utf8(),
+                    SubprogramDesignator::OperatorSymbol(ref latin1string) => {
+                        format!("\"{}\"", latin1string.to_string())
+                    }
+                },
+                detail: Some(String::from("Procedure")),
+                kind: SymbolKind::Method,
+                deprecated: None,
+                // Range should be "full range"
+                range: to_lsp_range(procedure.designator.pos.range()),
+                selection_range: to_lsp_range(procedure.designator.pos.range()),
+                children: None,
+            },
+            SubprogramDeclaration::Function(function) => DocumentSymbol {
+                name: match function.designator.item {
+                    SubprogramDesignator::Identifier(ref symbol) => symbol.name_utf8(),
+                    SubprogramDesignator::OperatorSymbol(ref latin1string) => {
+                        format!("\"{}\"", latin1string.to_string())
+                    }
+                },
+                detail: Some(String::from("Function")),
+                kind: SymbolKind::Function,
+                deprecated: None,
+                // Range should be "full range"
+                range: to_lsp_range(function.designator.pos.range()),
+                selection_range: to_lsp_range(function.designator.pos.range()),
+                children: None,
+            },
+        }
+    }
+}
+
+impl HasDocumentSymbol for InterfacePackageDeclaration {
+    fn document_symbol(&self) -> DocumentSymbol {
+        DocumentSymbol {
+            name: self.ident.item.name_utf8(),
+            detail: Some(String::from("Package")),
+            kind: SymbolKind::Package,
+            deprecated: None,
+            // Range should be "full range"
+            range: to_lsp_range(self.ident.pos.range()),
+            selection_range: to_lsp_range(self.ident.pos.range()),
+            children: None,
+        }
+    }
+}
+
+// @TODO: This is a copy from vhdl_server.rs
+fn to_lsp_pos(position: vhdl_lang::Position) -> lsp_types::Position {
+    lsp_types::Position {
+        line: position.line as u64,
+        character: position.character as u64,
+    }
+}
+
+// @TODO: This is a copy from vhdl_server.rs
+fn to_lsp_range(range: vhdl_lang::Range) -> lsp_types::Range {
+    lsp_types::Range {
+        start: to_lsp_pos(range.start),
+        end: to_lsp_pos(range.end),
+    }
+}
+
+fn none_if_empty<T>(vector: Vec<T>) -> Option<Vec<T>> {
+    if vector.is_empty() {
+        None
+    } else {
+        Some(vector)
+    }
+}
+
+fn mode_to_string(mode: &Mode) -> String {
+    String::from(match mode {
+        Mode::In => "in",
+        Mode::Out => "out",
+        Mode::InOut => "inout",
+        Mode::Buffer => "buffer",
+        Mode::Linkage => "linkage",
+    })
+}

--- a/vhdl_ls/src/lib.rs
+++ b/vhdl_ls/src/lib.rs
@@ -7,6 +7,7 @@
 #[macro_use]
 extern crate log;
 
+mod document_symbol;
 mod rpc_channel;
 mod stdio_server;
 mod vhdl_server;

--- a/vhdl_ls/src/stdio_server.rs
+++ b/vhdl_ls/src/stdio_server.rs
@@ -85,12 +85,21 @@ pub fn start() {
         serde_json::to_value(value).map_err(|_| jsonrpc_core::Error::internal_error())
     });
 
-    let server = lang_server;
+    let server = lang_server.clone();
     io.add_method("textDocument/references", move |params: Params| {
         let value = server
             .lock()
             .unwrap()
             .text_document_references(&params.parse().unwrap());
+        serde_json::to_value(value).map_err(|_| jsonrpc_core::Error::internal_error())
+    });
+
+    let server = lang_server;
+    io.add_method("textDocument/documentSymbol", move |params: Params| {
+        let value = server
+            .lock()
+            .unwrap()
+            .text_document_document_symbol(&params.parse().unwrap());
         serde_json::to_value(value).map_err(|_| jsonrpc_core::Error::internal_error())
     });
 


### PR DESCRIPTION
I started to play around with generating an outline by implementing the ["textDocument/documentSymbol"](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentSymbol) request.

In order to nicely generate the hierarchical outline in the image below, the language server needs to provide the `range` of the symbol (e.g for an entity the range from the `entity` keyword until the semicolon at the end of the entity) and the `selection_range` which could be the range of the identifier (can include `entity`).

![image](https://user-images.githubusercontent.com/2088771/80031309-c70d3780-84e9-11ea-9aca-8a84dffc0423.png)

Creating the response is fairly straight-forward (vhdl_ls/src/document_symbol.rs) except that the full range of the AST objects are not captured by the parser. I simpler form of outline could be created by only outlining named entities and using the range of the identifier, but in that case it is not possible to build the hierarchy.

The way I see it, the range annotations in the AST should be done down to and including `block_declarative_item` and `concurrent_statement` to build a really good outline. The range annotations could also be useful for getting snippets from the code for use in e.g. hovers.

I guess the annotation could be done in two ways, either wrapping the AST struct in a WithPos<> or adding a field to the struct. Both options would require some work since it impacts both the parser and analyzer plus requiring updates to the tests. Wrapping in WithPos<> I believe would minimize the test impact but instead make traversal less ergonomic as you would have to go though WithPos<>.item. I'm not sure how big hit it would be to performance to add the annotations.

When playing around I added a `pos: Option<SrcPos>` field as that was the quickest way to get a working concept to explore.

@kraigher Do you think that this is something worth discussing further?