### PR TITLE
Fix Clippy for current stable Rust (1.45.2)

### DIFF
--- a/.github/workflows/build-test-all.yml
+++ b/.github/workflows/build-test-all.yml
@@ -3,7 +3,6 @@ name: Build & test all configs
 on: [push, pull_request]
 
 jobs:
-
   release-notice:
     name: This is a release build
     if: startsWith(github.ref, 'refs/tags/v')
@@ -29,7 +28,7 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            ext: ''
+            ext: ""
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             ext: .exe
@@ -71,7 +70,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --package ${{ matrix.crate }} -- -D warnings
+          args: --package ${{ matrix.crate }} --all-targets --all-features -- -D warnings
 
       - name: Assemble
         if: matrix.rust == 'stable'
@@ -87,7 +86,7 @@ jobs:
         with:
           name: ${{ matrix.crate }}-${{ matrix.target }}
           path: ${{ matrix.crate }}-${{ matrix.target }}
-  
+
   release:
     name: Release
     if: startsWith(github.ref, 'refs/tags/v')

--- a/vhdl_lang/src/analysis/lock.rs
+++ b/vhdl_lang/src/analysis/lock.rs
@@ -167,13 +167,13 @@ mod tests {
         match lock.entry() {
             AnalysisEntry::Occupied(entry) => {
                 assert_eq!(*entry, 2);
-                assert_eq!(*entry.result(), 1.0);
+                assert!((*entry.result() - 1.0_f64).abs() < std::f64::EPSILON);
             }
             _ => panic!("Expected Occupied entry"),
         };
 
         assert_eq!(*lock.get().unwrap(), 2);
-        assert_eq!(*lock.get().unwrap().result(), 1.0);
+        assert!((*lock.get().unwrap().result() - 1.0_f64).abs() < std::f64::EPSILON);
 
         // Check that lock is reset
         lock.reset();

--- a/vhdl_lang/src/analysis/root.rs
+++ b/vhdl_lang/src/analysis/root.rs
@@ -637,7 +637,7 @@ mod tests {
     use super::*;
     use crate::syntax::test::{check_diagnostics, Code};
 
-    fn new_library_with_diagnostics<'a>(code: &Code, name: &str) -> (Library, Vec<Diagnostic>) {
+    fn new_library_with_diagnostics(code: &Code, name: &str) -> (Library, Vec<Diagnostic>) {
         let mut diagnostics = Vec::new();
         let mut library = Library::new(code.symbol(name));
         library.add_design_file(code.design_file());

--- a/vhdl_lang/src/analysis/tests/incremental_analysis.rs
+++ b/vhdl_lang/src/analysis/tests/incremental_analysis.rs
@@ -307,7 +307,7 @@ fn check_analysis_equal(got: &mut DesignRoot, expected: &mut DesignRoot) -> Vec<
     expected.analyze(&mut expected_diagnostics);
 
     // Check that diagnostics are equal to doing analysis from scratch
-    check_diagnostics(got_diagnostics.clone(), expected_diagnostics.clone());
+    check_diagnostics(got_diagnostics.clone(), expected_diagnostics);
 
     // Check that all references are equal, ensures the incremental
     // analysis has cleared refereces

--- a/vhdl_lang/src/analysis/tests/resolves_design_units.rs
+++ b/vhdl_lang/src/analysis/tests/resolves_design_units.rs
@@ -294,7 +294,7 @@ end architecture;
     // Find all references
     assert_eq_unordered(
         &root.find_all_references(&code.s1("ename1").pos()),
-        &vec![
+        &[
             code.s("ename1", 1).pos(),
             code.s("ename1", 2).pos(),
             code.s("ename1", 3).pos(),
@@ -403,7 +403,7 @@ end package body;
     // Find all references
     assert_eq_unordered(
         &root.find_all_references(&code.s1("pkg").pos()),
-        &vec![code.s("pkg", 1).pos(), code.s("pkg", 2).pos()],
+        &[code.s("pkg", 1).pos(), code.s("pkg", 2).pos()],
     );
 }
 

--- a/vhdl_lang/src/analysis/tests/resolves_type_mark.rs
+++ b/vhdl_lang/src/analysis/tests/resolves_type_mark.rs
@@ -147,7 +147,7 @@ end package;",
     // Cursor at end of symbol
     assert_eq!(
         root.search_reference(code2.source(), code2.s1("typ_t").end()),
-        Some(decl_pos.clone())
+        Some(decl_pos)
     );
 
     // Cursor after end of symbol
@@ -206,10 +206,10 @@ end package;",
     check_no_diagnostics(&diagnostics);
 
     let references = vec![
-        code1.s("typ_t", 1).pos().clone(),
-        code1.s("typ_t", 2).pos().clone(),
-        code2.s("typ_t", 1).pos().clone(),
-        code2.s("typ_t", 2).pos().clone(),
+        code1.s("typ_t", 1).pos(),
+        code1.s("typ_t", 2).pos(),
+        code2.s("typ_t", 1).pos(),
+        code2.s("typ_t", 2).pos(),
     ];
 
     assert_eq_unordered(
@@ -249,10 +249,7 @@ end package;",
 
     assert_eq_unordered(
         &root.find_all_references(&code.s("typ_t", 1).pos()),
-        &vec![
-            code.s("typ_t", 1).pos().clone(),
-            code.s("typ_t", 2).pos().clone(),
-        ],
+        &[code.s("typ_t", 1).pos(), code.s("typ_t", 2).pos()],
     );
 }
 

--- a/vhdl_lang/src/analysis/tests/util.rs
+++ b/vhdl_lang/src/analysis/tests/util.rs
@@ -29,10 +29,10 @@ impl LibraryBuilder {
         let library_name = self.code_builder.symbol(library_name);
         match self.libraries.entry(library_name) {
             Entry::Occupied(mut entry) => {
-                entry.get_mut().push(code.clone());
+                entry.get_mut().push(code);
             }
             Entry::Vacant(entry) => {
-                entry.insert(vec![code.clone()]);
+                entry.insert(vec![code]);
             }
         }
     }
@@ -102,7 +102,7 @@ pub fn add_standard_library(symbols: Arc<Symbols>, root: &mut DesignRoot) {
 
     root.add_design_file(std_sym.clone(), std_standard.design_file());
     root.add_design_file(std_sym.clone(), std_textio.design_file());
-    root.add_design_file(std_sym.clone(), std_env.design_file());
+    root.add_design_file(std_sym, std_env.design_file());
 }
 
 pub fn missing(code: &Code, name: &str, occ: usize) -> Diagnostic {

--- a/vhdl_lang/src/config.rs
+++ b/vhdl_lang/src/config.rs
@@ -311,7 +311,6 @@ fn is_literal(pattern: &str, is_windows: bool) -> bool {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
-    use tempfile;
 
     /// Utility function to create an empty file in parent folder
     fn touch(parent: &Path, file_name: &str) -> PathBuf {
@@ -444,7 +443,7 @@ lib3.files = [
         )
         .unwrap();
 
-        let mut merged_config = config0.clone();
+        let mut merged_config = config0;
         merged_config.append(&config1, &mut Vec::new());
         assert_eq!(merged_config, expected_config);
     }

--- a/vhdl_lang/src/data/contents.rs
+++ b/vhdl_lang/src/data/contents.rs
@@ -457,7 +457,7 @@ mod tests {
     fn character_is_utf16_len() {
         // Bomb emojii requires 2 utf-16 codes
         let bomb = '\u{1F4A3}';
-        let contents = new(&format!("aä{}", bomb).to_string());
+        let contents = new(&format!("aä{}", bomb));
         assert_eq!(contents.end(), Position::new(0, 4));
         let mut reader = reader(&contents);
         assert_eq!(reader.pop_char(), Some('a'));

--- a/vhdl_lang/src/data/source.rs
+++ b/vhdl_lang/src/data/source.rs
@@ -81,7 +81,6 @@ impl UniqueSource {
 
     #[cfg(test)]
     pub fn from_contents(file_name: &Path, contents: Contents) -> UniqueSource {
-        let file_name = file_name.into();
         Self {
             file_id: FileId::new(file_name),
             contents: RwLock::new(contents),
@@ -545,7 +544,6 @@ mod tests {
     use crate::data::Latin1String;
     use crate::syntax::test::{Code, CodeBuilder};
     use pretty_assertions::assert_eq;
-    use tempfile;
 
     #[test]
     fn srcpos_combine() {
@@ -568,7 +566,7 @@ mod tests {
         use std::io::Write;
         let mut file = tempfile::NamedTempFile::new().unwrap();
         let file_name = file.path().to_owned();
-        file.write(&Latin1String::from_utf8_unchecked(contents).bytes)
+        file.write_all(&Latin1String::from_utf8_unchecked(contents).bytes)
             .unwrap();
         fun(CodeBuilder::new().code_from_source(Source::from_latin1_file(&file_name).unwrap()))
     }

--- a/vhdl_lang/src/syntax/attributes.rs
+++ b/vhdl_lang/src/syntax/attributes.rs
@@ -112,8 +112,8 @@ pub fn parse_attribute(stream: &mut TokenStream) -> ParseResult<Vec<Attribute>> 
                 .map(|entity_name| {
                     Attribute::Specification(AttributeSpecification {
                         ident: ident.clone(),
-                        entity_name: entity_name,
-                        entity_class: entity_class,
+                        entity_name,
+                        entity_class,
                         expr: expr.clone(),
                     })
                 }).collect()

--- a/vhdl_lang/src/syntax/design_unit.rs
+++ b/vhdl_lang/src/syntax/design_unit.rs
@@ -297,7 +297,7 @@ mod tests {
 
     fn to_single_entity(design_file: DesignFile) -> EntityDeclaration {
         match design_file.design_units.as_slice() {
-            &[AnyDesignUnit::Primary(AnyPrimaryUnit::Entity(ref entity))] => entity.to_owned(),
+            [AnyDesignUnit::Primary(AnyPrimaryUnit::Entity(ref entity))] => entity.to_owned(),
             _ => panic!("Expected single entity {:?}", design_file),
         }
     }

--- a/vhdl_lang/src/syntax/expression.rs
+++ b/vhdl_lang/src/syntax/expression.rs
@@ -278,7 +278,7 @@ fn parse_primary_initial_token(
         }
         Null => Ok(WithPos {
             item: Expression::Literal(Literal::Null),
-            pos: token.pos.clone(),
+            pos: token.pos,
         }),
         New => {
             let alloc = parse_allocator(stream)?;

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -181,7 +181,7 @@ fn parse_function_call(
                     item: Name::FunctionCall(Box::new(FunctionCall {
                         name: prefix,
                         parameters: association_elements})),
-                    pos: pos,
+                    pos,
                 });
             }
         )
@@ -386,7 +386,7 @@ pub fn parse_name_initial_token(
 
                         name = WithPos {
                             item: Name::Slice(Box::new(name), Box::new(discrete_range)),
-                            pos: pos,
+                            pos,
                         };
                     },
                     RightPar => {
@@ -394,10 +394,10 @@ pub fn parse_name_initial_token(
                         name = WithPos {
                             item: Name::FunctionCall(Box::new(
                                 FunctionCall {
-                                    name: name,
+                                    name,
                                     parameters: vec![assoc]
                                 })),
-                            pos: pos,
+                            pos,
                         };
                     }
                 )
@@ -434,6 +434,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::blacklisted_name)]
     fn test_parse_selected_name_multiple() {
         let code = Code::new("foo.bar.baz");
         let baz = code
@@ -516,6 +517,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::blacklisted_name)]
     fn test_selected_name() {
         let code = Code::new("foo.bar.baz");
 
@@ -548,6 +550,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::blacklisted_name)]
     fn test_selected_name_all() {
         let code = Code::new("foo.all");
 
@@ -710,6 +713,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::blacklisted_name)]
     fn test_function_call_no_formal() {
         let code = Code::new("foo(0)");
 
@@ -783,6 +787,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::blacklisted_name)]
     fn test_function_call() {
         let code = Code::new("foo(arg => 0)");
 

--- a/vhdl_lang/src/syntax/subtype_indication.rs
+++ b/vhdl_lang/src/syntax/subtype_indication.rs
@@ -163,7 +163,7 @@ pub fn parse_element_resolution_indication(
                 };
 
                 element_resolutions.push(RecordElementResolution {
-                    ident: ident,
+                    ident,
                     resolution: Box::new(resolution),
                 });
 

--- a/vhdl_lang/src/syntax/test.rs
+++ b/vhdl_lang/src/syntax/test.rs
@@ -469,11 +469,11 @@ fn forward(stream: &mut TokenStream, start: Position) {
 }
 
 /// Check that no errors where found
-pub fn check_no_diagnostics(diagnostics: &Vec<Diagnostic>) {
+pub fn check_no_diagnostics(diagnostics: &[Diagnostic]) {
     for err in diagnostics.iter() {
         println!("{}", err.show());
     }
-    if diagnostics.len() > 0 {
+    if !diagnostics.is_empty() {
         panic!("Found errors");
     }
 }

--- a/vhdl_lang/src/syntax/tokens/tokenizer.rs
+++ b/vhdl_lang/src/syntax/tokens/tokenizer.rs
@@ -1641,7 +1641,7 @@ mod tests {
     }
 
     fn kinds(tokens: &[Token]) -> Vec<Kind> {
-        tokens.iter().map(|ref tok| tok.kind.clone()).collect()
+        tokens.iter().map(|ref tok| tok.kind).collect()
     }
 
     // Shorthand for testing
@@ -1654,7 +1654,7 @@ mod tests {
         Code::new(code)
             .tokenize()
             .iter()
-            .map(|tok| (tok.kind.clone(), tok.value.clone()))
+            .map(|tok| (tok.kind, tok.value.clone()))
             .collect()
     }
 
@@ -1933,12 +1933,13 @@ end entity"
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn tokenize_real_truncates_precision() {
         assert_eq!(
             kind_value_tokenize("2.71828182845904523536"),
             vec![(
                 AbstractLiteral,
-                Value::AbstractLiteral(ast::AbstractLiteral::Real(2.7182818284590452))
+                Value::AbstractLiteral(ast::AbstractLiteral::Real(2.718_281_828_459_045))
             )]
         );
     }
@@ -2078,7 +2079,7 @@ end entity"
                             kind: BitString,
                             value: Value::BitString(ast::BitString {
                                 length: length_opt,
-                                base: base,
+                                base,
                                 value: Latin1String::from_utf8_unchecked(value.as_str())
                             }),
                             pos: code.pos(),
@@ -2134,7 +2135,7 @@ end entity"
             kind_value_tokenize("16#eEFfa#"),
             vec![(
                 AbstractLiteral,
-                Value::AbstractLiteral(ast::AbstractLiteral::Integer(0xeEffa))
+                Value::AbstractLiteral(ast::AbstractLiteral::Integer(0xeeffa))
             ),]
         );
     }

--- a/vhdl_lang/src/syntax/type_declaration.rs
+++ b/vhdl_lang/src/syntax/type_declaration.rs
@@ -688,7 +688,7 @@ end protected body;
         assert_eq!(
             code.with_stream_no_diagnostics(parse_type_declaration),
             TypeDeclaration {
-                ident: ident.clone(),
+                ident,
                 def: TypeDefinition::ProtectedBody(ProtectedTypeBody {
                     type_reference: Reference::default(),
                     decl

--- a/vhdl_ls/src/rpc_channel.rs
+++ b/vhdl_ls/src/rpc_channel.rs
@@ -141,7 +141,7 @@ pub mod test_support {
         fn drop(&mut self) {
             if !std::thread::panicking() {
                 let expected = self.expected.replace(VecDeque::new());
-                if expected.len() > 0 {
+                if !expected.is_empty() {
                     panic!("Not all expected data was consumed\n{:#?}", expected);
                 }
             }

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -454,7 +454,6 @@ fn to_lsp_diagnostic(diagnostic: Diagnostic) -> lsp_types::Diagnostic {
 mod tests {
     use super::*;
     use crate::rpc_channel::test_support::*;
-    use tempfile;
 
     fn initialize_server(server: &mut VHDLServer<RpcMock>, root_uri: Url) {
         let capabilities = ClientCapabilities::default();
@@ -534,10 +533,10 @@ end entity ent;
 
         let did_open = DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
-                uri: file_url.clone(),
+                uri: file_url,
                 language_id: "vhdl".to_owned(),
                 version: 0,
-                text: code.to_owned(),
+                text: code,
             },
         };
 
@@ -566,7 +565,7 @@ end entity ent2;
                 uri: file_url.clone(),
                 language_id: "vhdl".to_owned(),
                 version: 0,
-                text: code.to_owned(),
+                text: code,
             },
         };
 
@@ -612,12 +611,12 @@ end entity ent;
             content_changes: vec![TextDocumentContentChangeEvent {
                 range: None,
                 range_length: None,
-                text: code.clone(),
+                text: code,
             }],
         };
 
         let publish_diagnostics = PublishDiagnosticsParams {
-            uri: file_url.clone(),
+            uri: file_url,
             diagnostics: vec![],
             version: None,
         };
@@ -664,7 +663,7 @@ lib.files = [
         );
 
         let publish_diagnostics = PublishDiagnosticsParams {
-            uri: file_uri.clone(),
+            uri: file_uri,
             diagnostics: vec![lsp_types::Diagnostic {
                 range: Range {
                     start: lsp_types::Position {
@@ -763,23 +762,21 @@ lib.files = [
         );
 
         expect_loaded_config_messages(&mock, &config_uri);
-        initialize_server(&mut server, root_uri.clone());
+        initialize_server(&mut server, root_uri);
 
         let did_open = DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
                 uri: file_url2.clone(),
                 language_id: "vhdl".to_owned(),
                 version: 0,
-                text: code2.to_owned(),
+                text: code2,
             },
         };
 
         server.text_document_did_open_notification(&did_open);
 
         let response = server.text_document_declaration(&TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier {
-                uri: file_url2.clone(),
-            },
+            text_document: TextDocumentIdentifier { uri: file_url2 },
             position: lsp_types::Position {
                 line: 2,
                 character: "  constant c : t".len() as u64,
@@ -787,7 +784,7 @@ lib.files = [
         });
 
         let expected = Location {
-            uri: file_url1.clone(),
+            uri: file_url1,
             range: Range {
                 start: lsp_types::Position {
                     line: 1,


### PR DESCRIPTION
I recently started to familiarize myself with the project and noticed that Clippy on the current stable Rust reports some warnings.
This PR should fix all of them and also enable Clippy checks for tests and non-default crate features (`--all-targets --all-features`) in GitHub build/test workflow.