### PR TITLE
Add explicit "pure" to the syntax parser

### DIFF
--- a/vhdl_lang/src/syntax/interface_declaration.rs
+++ b/vhdl_lang/src/syntax/interface_declaration.rs
@@ -227,7 +227,7 @@ fn parse_interface_declaration(
             let ident = stream.expect_ident()?;
             Ok(vec![InterfaceDeclaration::Type(ident)])
         },
-        Function | Procedure | Impure => {
+        Function | Procedure | Impure | Pure => {
             let decl = parse_subprogram_declaration_no_semi(stream, diagnostics)?;
             let default = parse_subprogram_default(stream)?;
 


### PR DESCRIPTION
The "pure" keyword was previously added to the tokenizer only.
Extending the syntax parser with "Pure" where "Impure" was used allows for parsing explicit pure functions correctly.

This closes #92.